### PR TITLE
fix: allow prefunded PDA in crank create

### DIFF
--- a/programs/hydra/src/processor/create.rs
+++ b/programs/hydra/src/processor/create.rs
@@ -23,7 +23,7 @@ use pinocchio::{
     sysvars::{rent::Rent, Sysvar},
     AccountView, Address, ProgramResult,
 };
-use pinocchio_system::instructions::CreateAccount;
+use pinocchio_system::instructions::{CreateAccountAllowPrefund, Funding};
 
 use hydra_api::{
     consts::{
@@ -115,12 +115,15 @@ pub fn process(accounts: &mut [AccountView], data: &[u8]) -> ProgramResult {
     ];
     let signers = [Signer::from(&seeds_arr)];
 
-    CreateAccount {
-        from: payer,
+    let funding_lamports = rent_min.saturating_sub(crank_ai.lamports());
+    CreateAccountAllowPrefund {
         to: crank_ai,
-        lamports: rent_min,
         space: total_size as u64,
         owner: &hydra_api::ID,
+        funding: (funding_lamports > 0).then_some(Funding {
+            from: payer,
+            lamports: funding_lamports,
+        }),
     }
     .invoke_signed(&signers)?;
 

--- a/programs/hydra/src/processor/create.rs
+++ b/programs/hydra/src/processor/create.rs
@@ -116,6 +116,9 @@ pub fn process(accounts: &mut [AccountView], data: &[u8]) -> ProgramResult {
     let signers = [Signer::from(&seeds_arr)];
 
     let funding_lamports = rent_min.saturating_sub(crank_ai.lamports());
+    if funding_lamports == 0 && !payer.is_signer() {
+        return Err(ProgramError::MissingRequiredSignature);
+    }
     CreateAccountAllowPrefund {
         to: crank_ai,
         space: total_size as u64,


### PR DESCRIPTION
## Summary
- The system program's `CreateAccount` requires the destination to hold 0 lamports, so anyone who pre-funds a crank PDA (the address is deterministic from the user-supplied `seed`) can permanently block `Create` for that seed.
- Switch to `pinocchio_system::CreateAccountAllowPrefund`, transferring only the rent shortfall when the PDA already has lamports.

## Test plan
- [ ] `cargo build -p hydra`
- [ ] Existing tests pass (`cargo test`)
- [ ] Manual: create a crank against a PDA that was pre-funded with 1 lamport — should now succeed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Account creation now only adds funds when truly needed, reducing unnecessary lamport transfers.
  * If extra funding is required, the payer must explicitly approve the transfer; operations will fail without that approval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->