### PR TITLE
chore: reduce crank timeout

### DIFF
--- a/crates/hydra-api/src/consts.rs
+++ b/crates/hydra-api/src/consts.rs
@@ -32,8 +32,8 @@ pub const MAX_COMPUTE_UNIT_LIMIT: u32 = 1_400_000;
 /// stuck and `Close` becomes permissionlessly callable. `next_exec_slot` only
 /// advances on successful `Trigger`, so a crank whose inner ix deterministically
 /// fails (or whose target is paused) would otherwise pin its rent forever.
-/// ~31 days at 400 ms/slot: 31 × 86_400 / 0.4 = 6_696_000.
-pub const STALENESS_THRESHOLD_SLOTS: u64 = 6_696_000;
+/// ~10 days at 400 ms/slot: 10 × 86_400 / 0.4 = 2_160_000.
+pub const STALENESS_THRESHOLD_SLOTS: u64 = 2_160_000;
 
 /// Per-meta size in both the on-chain template bytes and the instructions
 /// sysvar wire format: `[1 flag byte][32-byte pubkey]`.

--- a/crates/hydra-cranker/Cargo.toml
+++ b/crates/hydra-cranker/Cargo.toml
@@ -32,6 +32,7 @@ solana-commitment-config = "3.1"
 solana-instruction = { workspace = true }
 solana-keypair = "3.1"
 solana-message = "3.1"
+solana-signature = "3"
 solana-signer = "3"
 solana-transaction = "3.1"
 solana-hash = "4"

--- a/crates/hydra-cranker/src/fire.rs
+++ b/crates/hydra-cranker/src/fire.rs
@@ -1,5 +1,8 @@
 //! Build + submit crank transactions.
 
+use std::thread;
+use std::time::{Duration, Instant};
+
 use anyhow::{anyhow, Result};
 use solana_client::rpc_client::RpcClient;
 use solana_commitment_config::CommitmentLevel;
@@ -8,8 +11,16 @@ use solana_keypair::Keypair;
 use solana_message::Message;
 use solana_pubkey::{pubkey, Pubkey};
 use solana_rpc_client_api::config::RpcSendTransactionConfig;
+use solana_signature::Signature;
 use solana_signer::Signer;
 use solana_transaction::Transaction;
+
+/// How long `fire_trigger` waits to observe a `skip_preflight` tx land before
+/// returning an error. ~30 slots at 400 ms gives the leader and a couple of
+/// forks room to commit; longer than this and the tx is almost certainly
+/// dropped, which we want to surface as a failure so backoff kicks in.
+const SKIP_PREFLIGHT_CONFIRM_TIMEOUT: Duration = Duration::from_secs(15);
+const SKIP_PREFLIGHT_POLL_INTERVAL: Duration = Duration::from_millis(400);
 
 use hydra_api::instruction as ix;
 
@@ -75,23 +86,71 @@ pub fn fire_trigger(
     // Preflight catches reverts before the leader charges fees, but also
     // hides failures (no on-chain sig). Operators can opt into
     // `skip_preflight = true` to land failing txs on-chain for debugging.
-    rpc.send_transaction_with_config(
-        &tx,
-        RpcSendTransactionConfig {
-            skip_preflight,
-            max_retries: Some(5),
-            preflight_commitment: Some(CommitmentLevel::Processed),
-            ..Default::default()
-        },
-    )
-    .map_err(|e| {
-        metrics::metrics()
-            .rpc_errors_total
-            .with_label_values(&["send_transaction"])
-            .inc();
-        anyhow::Error::new(e).context("send_transaction")
-    })?;
+    let signature = rpc
+        .send_transaction_with_config(
+            &tx,
+            RpcSendTransactionConfig {
+                skip_preflight,
+                max_retries: Some(5),
+                preflight_commitment: Some(CommitmentLevel::Processed),
+                ..Default::default()
+            },
+        )
+        .map_err(|e| {
+            metrics::metrics()
+                .rpc_errors_total
+                .with_label_values(&["send_transaction"])
+                .inc();
+            anyhow::Error::new(e).context("send_transaction")
+        })?;
+
+    // With `skip_preflight = true`, the RPC returns once it accepts the
+    // packet — execution outcome isn't reflected in `Ok(_)`. Poll the
+    // signature so deterministic on-chain reverts surface as `Err` and the
+    // caller's failure/backoff bookkeeping treats them like preflight
+    // failures. With preflight on, the simulation already covers this and
+    // the extra round-trip is unnecessary.
+    if skip_preflight {
+        confirm_or_fail(rpc, &signature)?;
+    }
     Ok(())
+}
+
+/// Poll `signature` until the cluster reports a status or the timeout
+/// elapses. An on-chain `Err(_)` becomes our `Err`. A `None` (not seen)
+/// also becomes `Err` so callers throttle dropped txs the same as failures
+/// — better to back off and retry next slot than to retransmit a doomed
+/// crank every cooldown.
+fn confirm_or_fail(rpc: &RpcClient, signature: &Signature) -> Result<()> {
+    let deadline = Instant::now() + SKIP_PREFLIGHT_CONFIRM_TIMEOUT;
+    loop {
+        match rpc.get_signature_status(signature) {
+            Ok(Some(Ok(()))) => return Ok(()),
+            Ok(Some(Err(tx_err))) => {
+                metrics::metrics()
+                    .rpc_errors_total
+                    .with_label_values(&["on_chain_err"])
+                    .inc();
+                return Err(anyhow!("tx {signature} reverted on-chain: {tx_err:?}"));
+            }
+            Ok(None) => {
+                if Instant::now() >= deadline {
+                    return Err(anyhow!(
+                        "tx {signature} not observed within {:?}",
+                        SKIP_PREFLIGHT_CONFIRM_TIMEOUT
+                    ));
+                }
+                thread::sleep(SKIP_PREFLIGHT_POLL_INTERVAL);
+            }
+            Err(e) => {
+                metrics::metrics()
+                    .rpc_errors_total
+                    .with_label_values(&["get_signature_status"])
+                    .inc();
+                return Err(anyhow::Error::new(e).context("get_signature_status"));
+            }
+        }
+    }
 }
 
 /// Submit a permissionless `Close`. The cranker keeps the `CRANKER_REWARD`

--- a/crates/hydra-cranker/src/fire.rs
+++ b/crates/hydra-cranker/src/fire.rs
@@ -47,6 +47,7 @@ pub fn fire_trigger(
     cranker: &Keypair,
     entry: &CrankEntry,
     priority_fee_micro_lamports: u64,
+    skip_preflight: bool,
 ) -> Result<()> {
     let scheduled = ix::scheduled_ix_from_crank(&entry.data)
         .ok_or_else(|| anyhow!("malformed crank tail for {}", entry.pubkey))?;
@@ -71,11 +72,13 @@ pub fn fire_trigger(
     ixs.push(scheduled);
     let msg = Message::new_with_blockhash(&ixs, Some(&cranker.pubkey()), &blockhash);
     let tx = Transaction::new(&[cranker], msg, blockhash);
-    // Preflight on: reverts are caught before the leader charges fees.
+    // Preflight catches reverts before the leader charges fees, but also
+    // hides failures (no on-chain sig). Operators can opt into
+    // `skip_preflight = true` to land failing txs on-chain for debugging.
     rpc.send_transaction_with_config(
         &tx,
         RpcSendTransactionConfig {
-            skip_preflight: false,
+            skip_preflight,
             max_retries: Some(5),
             preflight_commitment: Some(CommitmentLevel::Processed),
             ..Default::default()

--- a/crates/hydra-cranker/src/main.rs
+++ b/crates/hydra-cranker/src/main.rs
@@ -99,6 +99,16 @@ struct Cli {
         default_value_t = 0
     )]
     priority_fee_micro_lamports: u64,
+    /// Send `Trigger` txs with `skip_preflight = true`. Off by default so
+    /// preflight catches reverts before the leader charges fees. Turn on to
+    /// surface failing inner ixs on-chain (otherwise they stall in simulation
+    /// and never produce a signature, hiding the failure mode).
+    #[arg(
+        long,
+        env = "HYDRA_CRANKER_TRIGGER_SKIP_PREFLIGHT",
+        default_value_t = false
+    )]
+    trigger_skip_preflight: bool,
 }
 
 fn default_ws_url(rpc_url: &str) -> String {
@@ -273,7 +283,13 @@ fn main() -> Result<()> {
                     }
                 }
             }
-            match fire::fire_trigger(&rpc, &cranker, &entry, args.priority_fee_micro_lamports) {
+            match fire::fire_trigger(
+                &rpc,
+                &cranker,
+                &entry,
+                args.priority_fee_micro_lamports,
+                args.trigger_skip_preflight,
+            ) {
                 Ok(()) => {
                     log::info!("slot {}: triggered {}", slot, entry.pubkey);
                     metrics::metrics()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced `--trigger-skip-preflight` configuration option, allowing operators to control whether preflight validation is performed during transaction submission.
  * Reduced the staleness threshold used to identify inactive cranks from approximately 31 days to 10 days, enabling faster detection of stuck operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->