### PR TITLE
Add cranker health check

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ hydra-cranker \
   --ws-url wss://your.rpc.example
 
 # With Prometheus metrics at http://0.0.0.0:9100/metrics
+# and JSON health at http://0.0.0.0:9100/healthz
 hydra-cranker \
   --keypair ~/.config/solana/cranker.json \
   --prometheus-port 9100
@@ -218,14 +219,23 @@ hydra-cranker \
 ### Metrics
 
 When `--prometheus-port <PORT>` is set the cranker serves `/metrics` in
-Prometheus text format on `0.0.0.0:<PORT>`. All series are namespaced
-`hydra_cranker_*` and pre-initialised so `rate()` works from scrape 1.
+Prometheus text format and `/healthz` in JSON on `0.0.0.0:<PORT>`. All series
+are namespaced `hydra_cranker_*` and pre-initialised so `rate()` works from
+scrape 1.
+
+`/healthz` returns `200` while the slot stream is fresh and no eligible crank is
+parked after repeated failures. It returns `503` before the first slot, when the
+last slot sweep is older than 30 seconds, when eligible cranks are parked, or
+when triggerable cranks were not attempted on the latest sweep.
 
 | Metric | Type | Labels | Meaning |
 |---|---|---|---|
 | `cranks_cached` | gauge | — | Cranks currently in the in-memory cache. |
 | `current_slot` | gauge | — | Last slot observed from `slotSubscribe`. |
 | `eligible_now` | gauge | — | Cranks eligible to trigger on the last slot tick. |
+| `triggerable_now` | gauge | — | Eligible cranks after local cooldown/backoff filtering. |
+| `parked_now` | gauge | — | Eligible cranks parked after repeated failures at the same `next_exec_slot`. |
+| `max_overdue_slots` | gauge | — | Largest `current_slot - next_exec_slot` among currently eligible cranks. |
 | `triggers_submitted_total` | counter | `result={ok,err}` | Triggers submitted. |
 | `ws_reconnects_total` | counter | `source={program,slot}` | WS (re)connect attempts. |
 | `grpc_reconnects_total` | counter | `source={program,slot}` | Yellowstone gRPC (re)connect attempts (only when `--grpc-url` is set). |
@@ -237,6 +247,7 @@ Useful alerts:
 
 - `increase(hydra_cranker_current_slot[1m]) < 100` — WS wedged.
 - `hydra_cranker_cranks_cached == 0` and `hydra_cranker_ws_reconnects_total > 2` — not subscribed / flaky endpoint.
+- `hydra_cranker_parked_now > 0` — at least one eligible crank repeatedly failed and is no longer being retried.
 - `rate(hydra_cranker_triggers_submitted_total{result="err"}[5m]) / rate(hydra_cranker_triggers_submitted_total[5m]) > 0.5` — majority of triggers failing.
 - `hydra_cranker_eligible_now > 0` for >30 s with no `rate(triggers_submitted_total[1m])` — have work, not doing it.
 - `histogram_quantile(0.99, rate(hydra_cranker_sweep_duration_seconds_bucket[5m])) > 0.05` — sweep p99 > 50 ms, perf regression or cache bloat.

--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ when triggerable cranks were not attempted on the latest sweep.
 | `parked_now` | gauge | — | Eligible cranks parked after repeated failures at the same `next_exec_slot`. |
 | `max_overdue_slots` | gauge | — | Largest `current_slot - next_exec_slot` among currently eligible cranks. |
 | `triggers_submitted_total` | counter | `result={ok,err}` | Triggers submitted. |
+| `closes_submitted_total` | counter | `result={ok,err}` | Permissionless `Close` transactions submitted. |
 | `ws_reconnects_total` | counter | `source={program,slot}` | WS (re)connect attempts. |
 | `grpc_reconnects_total` | counter | `source={program,slot}` | Yellowstone gRPC (re)connect attempts (only when `--grpc-url` is set). |
 | `cache_events_total` | counter | `kind={insert,update,remove}` | Cache mutations driven by `programSubscribe`. |

--- a/crates/hydra-cranker/src/main.rs
+++ b/crates/hydra-cranker/src/main.rs
@@ -169,6 +169,7 @@ fn main() -> Result<()> {
     let mut failures: HashMap<Pubkey, FailureState> = HashMap::new();
     let mut last_submit: HashMap<Pubkey, u64> = HashMap::new();
     let mut last_close_attempt: HashMap<Pubkey, u64> = HashMap::new();
+    let mut last_trigger_attempt_slot: Option<u64> = None;
 
     // Prometheus metrics endpoint (optional).
     if let Some(port) = args.prometheus_port {
@@ -263,9 +264,14 @@ fn main() -> Result<()> {
         failures.retain(|pk, _| live_pubkeys.contains(pk));
         last_submit.retain(|pk, _| live_pubkeys.contains(pk));
         last_close_attempt.retain(|pk, _| live_pubkeys.contains(pk));
-        metrics::metrics().eligible_now.set(eligible.len() as i64);
+        let eligible_now = eligible.len();
+        metrics::metrics().eligible_now.set(eligible_now as i64);
 
+        let mut max_overdue_slots = 0;
+        let mut parked_now = 0;
+        let mut triggerable = Vec::new();
         for entry in eligible {
+            max_overdue_slots = max_overdue_slots.max(slot.saturating_sub(entry.next_exec_slot));
             if let Some(&at) = last_submit.get(&entry.pubkey) {
                 if slot < at + POST_SUBMIT_COOLDOWN_SLOTS {
                     continue;
@@ -276,6 +282,7 @@ fn main() -> Result<()> {
             if let Some(state) = failures.get(&entry.pubkey) {
                 if state.at_slot == entry.next_exec_slot {
                     if state.count >= MAX_CONSECUTIVE_FAILURES {
+                        parked_now += 1;
                         continue;
                     }
                     if slot < state.next_retry_slot {
@@ -283,6 +290,12 @@ fn main() -> Result<()> {
                     }
                 }
             }
+            triggerable.push(entry);
+        }
+        let triggerable_now = triggerable.len();
+
+        for entry in triggerable {
+            last_trigger_attempt_slot = Some(slot);
             match fire::fire_trigger(
                 &rpc,
                 &cranker,
@@ -334,6 +347,14 @@ fn main() -> Result<()> {
                 }
             }
         }
+        metrics::update_health(metrics::HealthSnapshot::observed(
+            slot,
+            eligible_now,
+            triggerable_now,
+            parked_now,
+            max_overdue_slots,
+            last_trigger_attempt_slot,
+        ));
 
         for entry in closable {
             if let Some(&at) = last_close_attempt.get(&entry.pubkey) {

--- a/crates/hydra-cranker/src/main.rs
+++ b/crates/hydra-cranker/src/main.rs
@@ -8,7 +8,7 @@ use std::{
         atomic::{AtomicBool, AtomicUsize, Ordering},
         mpsc, Arc,
     },
-    time::Duration,
+    time::{Duration, Instant},
 };
 
 use anyhow::{anyhow, Result};
@@ -235,8 +235,8 @@ fn main() -> Result<()> {
         if shutdown.load(Ordering::Relaxed) {
             break;
         }
-        let slot = match slot_rx.recv_timeout(Duration::from_millis(500)) {
-            Ok(slot) => slot,
+        let (slot, slot_observed_at) = match slot_rx.recv_timeout(Duration::from_millis(500)) {
+            Ok(slot) => (slot, Instant::now()),
             Err(mpsc::RecvTimeoutError::Timeout) => continue,
             Err(mpsc::RecvTimeoutError::Disconnected) => break,
         };
@@ -349,6 +349,7 @@ fn main() -> Result<()> {
         }
         metrics::update_health(metrics::HealthSnapshot::observed(
             slot,
+            slot_observed_at,
             eligible_now,
             triggerable_now,
             parked_now,

--- a/crates/hydra-cranker/src/metrics.rs
+++ b/crates/hydra-cranker/src/metrics.rs
@@ -1,12 +1,16 @@
-//! Prometheus metrics + `/metrics` HTTP endpoint.
+//! Prometheus metrics + `/metrics` and `/healthz` HTTP endpoints.
 //!
-//! Minimal on purpose: five metrics, a `OnceLock` holding the registry,
-//! and a blocking `tiny_http` server thread. No async runtime, no middleware.
+//! Minimal on purpose: one registry, a health snapshot, and a blocking
+//! `tiny_http` server thread. No async runtime, no middleware.
 //!
 //! All metrics are namespaced `hydra_cranker_*`. Scrape with any Prometheus
 //! (`curl http://host:PORT/metrics` for a sanity check).
 
-use std::{sync::OnceLock, thread, time::Duration};
+use std::{
+    sync::{Mutex, OnceLock},
+    thread,
+    time::{Duration, Instant},
+};
 
 use prometheus::{
     register_histogram_with_registry, register_int_counter_vec_with_registry,
@@ -45,6 +49,15 @@ pub struct Metrics {
     /// Cranks that were eligible on the most recent slot tick (ready to
     /// trigger). Point-in-time snapshot, overwritten every scan.
     pub eligible_now: IntGauge,
+
+    /// Cranks eligible after local cooldown/backoff filtering.
+    pub triggerable_now: IntGauge,
+
+    /// Eligible cranks parked after repeated failures at the same next_exec_slot.
+    pub parked_now: IntGauge,
+
+    /// Largest `current_slot - next_exec_slot` among currently eligible cranks.
+    pub max_overdue_slots: IntGauge,
 
     /// Duration of each slot-tick sweep: scan cache + fire all eligible.
     /// Custom fine-grained buckets targeted at the <10 ms healthy range.
@@ -111,6 +124,24 @@ impl Metrics {
             registry
         )
         .unwrap();
+        let triggerable_now = register_int_gauge_with_registry!(
+            "triggerable_now",
+            "Cranks eligible after local cooldown/backoff filtering.",
+            registry
+        )
+        .unwrap();
+        let parked_now = register_int_gauge_with_registry!(
+            "parked_now",
+            "Eligible cranks parked after repeated failures at the same next_exec_slot.",
+            registry
+        )
+        .unwrap();
+        let max_overdue_slots = register_int_gauge_with_registry!(
+            "max_overdue_slots",
+            "Largest current_slot - next_exec_slot among currently eligible cranks.",
+            registry
+        )
+        .unwrap();
         // Fine-grained buckets targeted at the healthy sub-10ms range; upper
         // buckets catch pathological sweeps (stuck lock, bursty RPC).
         let sweep_duration_seconds = register_histogram_with_registry!(
@@ -168,6 +199,9 @@ impl Metrics {
             grpc_reconnects_total,
             cache_events_total,
             eligible_now,
+            triggerable_now,
+            parked_now,
+            max_overdue_slots,
             sweep_duration_seconds,
             rpc_errors_total,
         }
@@ -180,7 +214,94 @@ pub fn metrics() -> &'static Metrics {
     METRICS.get_or_init(Metrics::new)
 }
 
-/// Spawn a blocking HTTP server serving `GET /metrics` in text format.
+const HEALTH_SLOT_STALE_AFTER: Duration = Duration::from_secs(30);
+
+#[derive(Clone, Copy, Debug, Default)]
+pub struct HealthSnapshot {
+    pub slot: Option<u64>,
+    pub slot_observed_at: Option<Instant>,
+    pub eligible_now: usize,
+    pub triggerable_now: usize,
+    pub parked_now: usize,
+    pub max_overdue_slots: u64,
+    pub last_trigger_attempt_slot: Option<u64>,
+}
+
+impl HealthSnapshot {
+    pub fn observed(
+        slot: u64,
+        eligible_now: usize,
+        triggerable_now: usize,
+        parked_now: usize,
+        max_overdue_slots: u64,
+        last_trigger_attempt_slot: Option<u64>,
+    ) -> Self {
+        Self {
+            slot: Some(slot),
+            slot_observed_at: Some(Instant::now()),
+            eligible_now,
+            triggerable_now,
+            parked_now,
+            max_overdue_slots,
+            last_trigger_attempt_slot,
+        }
+    }
+}
+
+static HEALTH: OnceLock<Mutex<HealthSnapshot>> = OnceLock::new();
+
+fn health() -> &'static Mutex<HealthSnapshot> {
+    HEALTH.get_or_init(|| Mutex::new(HealthSnapshot::default()))
+}
+
+pub fn update_health(snapshot: HealthSnapshot) {
+    metrics()
+        .triggerable_now
+        .set(snapshot.triggerable_now as i64);
+    metrics().parked_now.set(snapshot.parked_now as i64);
+    metrics()
+        .max_overdue_slots
+        .set(snapshot.max_overdue_slots as i64);
+    *health().lock().expect("health snapshot poisoned") = snapshot;
+}
+
+fn render_health() -> (tiny_http::StatusCode, Vec<u8>) {
+    let snapshot = *health().lock().expect("health snapshot poisoned");
+    let slot_age_ms = snapshot.slot_observed_at.map(|at| at.elapsed().as_millis());
+    let (ok, reason) = match (snapshot.slot, slot_age_ms) {
+        (None, _) => (false, "no slots observed"),
+        (_, Some(age)) if age > HEALTH_SLOT_STALE_AFTER.as_millis() => (false, "slot stream stale"),
+        (_, _) if snapshot.parked_now > 0 => (false, "parked eligible cranks"),
+        (Some(slot), _)
+            if snapshot.triggerable_now > 0 && snapshot.last_trigger_attempt_slot != Some(slot) =>
+        {
+            (false, "triggerable cranks not attempted")
+        }
+        _ => (true, "ok"),
+    };
+    let status = if ok { 200 } else { 503 };
+    let slot = snapshot
+        .slot
+        .map(|s| s.to_string())
+        .unwrap_or_else(|| "null".to_string());
+    let slot_age_ms = slot_age_ms
+        .map(|age| age.to_string())
+        .unwrap_or_else(|| "null".to_string());
+    let last_trigger_attempt_slot = snapshot
+        .last_trigger_attempt_slot
+        .map(|s| s.to_string())
+        .unwrap_or_else(|| "null".to_string());
+    let body = format!(
+        "{{\"ok\":{ok},\"reason\":\"{reason}\",\"slot\":{slot},\"slot_age_ms\":{slot_age_ms},\"eligible_now\":{},\"triggerable_now\":{},\"parked_now\":{},\"max_overdue_slots\":{},\"last_trigger_attempt_slot\":{last_trigger_attempt_slot}}}\n",
+        snapshot.eligible_now,
+        snapshot.triggerable_now,
+        snapshot.parked_now,
+        snapshot.max_overdue_slots,
+    );
+    (tiny_http::StatusCode(status), body.into_bytes())
+}
+
+/// Spawn a blocking HTTP server serving `GET /metrics` and `GET /healthz`.
 /// The server thread runs for the lifetime of the process; on any bind
 /// failure it logs and exits the thread (the cranker stays up).
 pub fn spawn_server(port: u16) -> thread::JoinHandle<()> {
@@ -193,23 +314,35 @@ pub fn spawn_server(port: u16) -> thread::JoinHandle<()> {
                 return;
             }
         };
-        log::info!("metrics server listening on {addr}/metrics");
+        log::info!("metrics server listening on {addr}/metrics and {addr}/healthz");
         let metrics = metrics();
         let encoder = TextEncoder::new();
         // 1s poll so a clean process exit can proceed within bounded time.
         loop {
             match server.recv_timeout(Duration::from_secs(1)) {
                 Ok(Some(req)) => {
-                    let mut body = Vec::with_capacity(1024);
-                    if let Err(e) = encoder.encode(&metrics.registry.gather(), &mut body) {
-                        log::warn!("metrics encode error: {e}");
-                        continue;
-                    }
-                    let resp = tiny_http::Response::from_data(body).with_header(
-                        "Content-Type: text/plain; version=0.0.4"
-                            .parse::<tiny_http::Header>()
-                            .unwrap(),
-                    );
+                    let path = req.url().split('?').next().unwrap_or(req.url()).to_string();
+                    let resp = if path == "/healthz" {
+                        let (status, body) = render_health();
+                        tiny_http::Response::from_data(body)
+                            .with_status_code(status)
+                            .with_header(
+                                "Content-Type: application/json"
+                                    .parse::<tiny_http::Header>()
+                                    .unwrap(),
+                            )
+                    } else {
+                        let mut body = Vec::with_capacity(1024);
+                        if let Err(e) = encoder.encode(&metrics.registry.gather(), &mut body) {
+                            log::warn!("metrics encode error: {e}");
+                            continue;
+                        }
+                        tiny_http::Response::from_data(body).with_header(
+                            "Content-Type: text/plain; version=0.0.4"
+                                .parse::<tiny_http::Header>()
+                                .unwrap(),
+                        )
+                    };
                     let _ = req.respond(resp);
                 }
                 Ok(None) => {} // timeout, just loop

--- a/crates/hydra-cranker/src/metrics.rs
+++ b/crates/hydra-cranker/src/metrics.rs
@@ -230,6 +230,7 @@ pub struct HealthSnapshot {
 impl HealthSnapshot {
     pub fn observed(
         slot: u64,
+        slot_observed_at: Instant,
         eligible_now: usize,
         triggerable_now: usize,
         parked_now: usize,
@@ -238,7 +239,7 @@ impl HealthSnapshot {
     ) -> Self {
         Self {
             slot: Some(slot),
-            slot_observed_at: Some(Instant::now()),
+            slot_observed_at: Some(slot_observed_at),
             eligible_now,
             triggerable_now,
             parked_now,


### PR DESCRIPTION
## Summary
- add a `/healthz` JSON endpoint on the existing cranker metrics server
- expose triggerable, parked, and max-overdue crank gauges
- document the health endpoint and new Prometheus signals

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a JSON health endpoint at `/healthz` alongside Prometheus metrics at `/metrics`.
  * Expanded monitoring with new gauges for triggerable, parked, and overdue cranks.
* **Bug Fixes**
  * Health responses now return `200` when healthy and `503` when issues are detected, including stale data or parked eligible cranks.
* **Documentation**
  * Updated metrics docs and alerts to reflect the new health checks and metric series.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->