### PR TITLE
fix(cranker): reconnect slot watch when the stream goes silent

### DIFF
--- a/crates/hydra-cranker/src/watch.rs
+++ b/crates/hydra-cranker/src/watch.rs
@@ -11,7 +11,11 @@
 //!
 //! Both threads auto-reconnect on disconnect with a fixed 5 s backoff.
 //! On reconnect the cache is re-bootstrapped via `getProgramAccounts` so
-//! we don't silently drift.
+//! we don't silently drift. The slot watcher additionally treats prolonged
+//! silence as a disconnect: slots flow constantly on a healthy cluster, so
+//! a quiet stream means the socket died without a close frame (half-open
+//! connection) and must be torn down. The program watcher cannot do the
+//! same — an idle program is indistinguishable from a dead socket there.
 
 use std::{
     sync::{
@@ -19,7 +23,7 @@ use std::{
         mpsc, Arc,
     },
     thread,
-    time::Duration,
+    time::{Duration, Instant},
 };
 
 use crossbeam_channel::RecvTimeoutError;
@@ -194,21 +198,36 @@ pub fn spawn_slot_watcher(
     })
 }
 
+/// A healthy cluster emits a slot roughly every 400 ms. If the subscription
+/// stays silent this long, the connection died without a close frame and the
+/// channel will never report `Disconnected`; bail so the reconnect loop can
+/// rebuild it.
+const SLOT_SILENCE_LIMIT: Duration = Duration::from_secs(30);
+
 fn run_slot_watch(ws_url: &str, shutdown: &AtomicBool, tick: &mpsc::Sender<u64>) -> Result<()> {
     let (_sub, rx) = PubsubClient::slot_subscribe(ws_url).context("slotSubscribe connect")?;
     log::info!("slotSubscribe connected");
+    let mut last_slot_at = Instant::now();
     loop {
         if shutdown.load(Ordering::Relaxed) {
             break Ok(());
         }
         match rx.recv_timeout(Duration::from_secs(10)) {
             Ok(info) => {
+                last_slot_at = Instant::now();
                 // If the receiver went away, we have nothing to do.
                 if tick.send(info.slot).is_err() {
                     break Ok(());
                 }
             }
-            Err(RecvTimeoutError::Timeout) => continue,
+            Err(RecvTimeoutError::Timeout) => {
+                let silent = last_slot_at.elapsed();
+                if silent >= SLOT_SILENCE_LIMIT {
+                    anyhow::bail!(
+                        "no slot notification in {silent:?}; connection presumed half-open"
+                    );
+                }
+            }
             Err(RecvTimeoutError::Disconnected) => {
                 anyhow::bail!("slotSubscribe channel disconnected")
             }


### PR DESCRIPTION
## Problem

The devnet cranker stopped triggering for two weeks while the service stayed `active (running)` — armed, funded cranks piled up untriggered until a manual restart cleared the backlog.

Root cause: `run_slot_watch` only exits on `RecvTimeoutError::Disconnected`, but a half-open websocket (server vanished without a close frame — NAT/idle drops, provider-side kills) never disconnects the channel. `recv_timeout` kept timing out and the loop spun forever with `continue`. Since triggers are only evaluated on slot ticks, the whole cranker silently froze. Logs showed `slotSubscribe` silent for 34h while `programSubscribe` (which the RPC provider closes explicitly on inactivity) kept reconnecting normally and caching new cranks — 65 cached, none fired.

## Fix

Slots flow constantly (~400 ms) on a healthy cluster, so prolonged silence is proof of a dead socket, not idleness. Track the last notification time and bail after `SLOT_SILENCE_LIMIT` (30 s) without one; the existing reconnect loop (5 s backoff, `ws_reconnects_total{source="slot"}` metric) rebuilds the subscription.

The program watcher is deliberately left unchanged: an idle program is indistinguishable from a dead socket there, and bailing on silence would re-run the `getProgramAccounts` bootstrap on every quiet stretch.

## Testing

- `cargo check`, `cargo clippy`, `cargo test -p hydra-cranker` all clean.
- Incident verified end-to-end on devnet: after restart the backlog fired instantly (6 cranks in ~2 s) and Rip→Settle→Deliver returned to ~1 s latency.

Follow-up: #12 handles a second degradation mode (throttled stream lagging the chain) observed after this fix was deployed.
