### PR TITLE
chore: CI workflow and Makefile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Install Rust (rustfmt)
         uses: dtolnay/rust-toolchain@master
@@ -46,6 +48,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Install Rust (clippy)
         uses: dtolnay/rust-toolchain@master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
         run: make fmt-check
 
   # ---------------------------------------------------------------------------
-  # Default feature set: lint + tests with the `ephemeral` feature OFF.
+  # Default feature set: lint + the full test suite (workspace + examples).
   # ---------------------------------------------------------------------------
   default:
     name: lint + test (default)
@@ -59,7 +59,8 @@ jobs:
 
       - name: Install Solana toolchain (build-sbf)
         run: |
-          sh -c "$(curl -sSfL https://release.anza.xyz/${SOLANA_VERSION}/install)"
+          curl -sSfL -o "$RUNNER_TEMP/solana-install" "https://release.anza.xyz/${SOLANA_VERSION}/install"
+          sh "$RUNNER_TEMP/solana-install"
           echo "$HOME/.local/share/solana/install/active_release/bin" >> "$GITHUB_PATH"
 
       # Keep the version in sync with `[toolchain] anchor_version` in

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,8 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: -D warnings
-  # Pinned Solana/Agave toolchain that ships `cargo build-sbf`.
   SOLANA_VERSION: v4.0.1
+  ANCHOR_VERSION: 1.0.2
 
 jobs:
   # ---------------------------------------------------------------------------
@@ -61,6 +61,16 @@ jobs:
         run: |
           sh -c "$(curl -sSfL https://release.anza.xyz/${SOLANA_VERSION}/install)"
           echo "$HOME/.local/share/solana/install/active_release/bin" >> "$GITHUB_PATH"
+
+      # Keep the version in sync with `[toolchain] anchor_version` in
+      # examples/anchor/Anchor.toml — on a mismatch the CLI reaches for avm.
+      - name: Install Anchor CLI (build + test the anchor example)
+        run: |
+          mkdir -p "$HOME/.local/bin"
+          curl -sSfL -o "$HOME/.local/bin/anchor" \
+            https://github.com/solana-foundation/anchor/releases/download/v${ANCHOR_VERSION}/anchor-${ANCHOR_VERSION}-x86_64-unknown-linux-gnu
+          chmod +x "$HOME/.local/bin/anchor"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Install cargo-nextest
         uses: taiki-e/install-action@nextest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,64 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+# Cancel superseded runs on the same ref to save runner minutes.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: -D warnings
+  # Pinned Solana/Agave toolchain that ships `cargo build-sbf`.
+  SOLANA_VERSION: stable
+
+jobs:
+  # ---------------------------------------------------------------------------
+  # Formatting — covers all root workspace members.
+  # ---------------------------------------------------------------------------
+  fmt:
+    name: rustfmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust (rustfmt)
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.91.1
+          components: rustfmt
+
+      - name: Check formatting
+        run: make fmt-check
+
+  # ---------------------------------------------------------------------------
+  # Default feature set: lint + tests with the `ephemeral` feature OFF.
+  # ---------------------------------------------------------------------------
+  default:
+    name: lint + test (default)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust (clippy)
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.91.1
+          components: clippy,rustfmt
+
+      - name: Install Solana toolchain (build-sbf)
+        run: |
+          sh -c "$(curl -sSfL https://release.anza.xyz/${SOLANA_VERSION}/install)"
+          echo "$HOME/.local/share/solana/install/active_release/bin" >> "$GITHUB_PATH"
+
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@nextest
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Default CI checks
+        run: make ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: -D warnings
   # Pinned Solana/Agave toolchain that ships `cargo build-sbf`.
-  SOLANA_VERSION: stable
+  SOLANA_VERSION: v4.0.1
 
 jobs:
   # ---------------------------------------------------------------------------

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 # Cancel superseded runs on the same ref to save runner minutes.
 concurrency:
   group: ci-${{ github.ref }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-/target
+target/
 # Anchor example is its own workspace with its own target dir.
 /examples/anchor/target
 Cargo.lock

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,9 @@ ANCHOR_MANIFEST    := examples/anchor/Cargo.toml
 
 CLIPPY := --all-targets -- -D warnings
 
+RUSTFLAGS ?= -D warnings
+export RUSTFLAGS
+
 .PHONY: help
 help: ## Show this help
 	@grep -hE '^[a-zA-Z0-9_-]+:.*?## ' $(MAKEFILE_LIST) \

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,8 @@ NATIVE_MANIFEST    := examples/native/Cargo.toml
 PINOCCHIO_MANIFEST := examples/pinocchio/Cargo.toml
 ANCHOR_MANIFEST    := examples/anchor/Cargo.toml
 
+HYDRA_FEATURES := logging,cu-trace
+
 CLIPPY := --all-targets -- -D warnings
 
 RUSTFLAGS ?= -D warnings
@@ -37,7 +39,7 @@ help: ## Show this help
 # ---------------------------------------------------------------------------
 .PHONY: build build-examples build-anchor
 
-build: ## build-sbf the noop + base + ephemeral hydra programs
+build: ## build-sbf the noop + hydra programs
 	cargo build-sbf --manifest-path $(NOOP_MANIFEST)
 	cargo build-sbf --manifest-path $(BASE_MANIFEST)
 
@@ -64,9 +66,10 @@ fmt-check: ## Check formatting without writing (CI)
 	cargo fmt --all --check
 	cargo fmt --manifest-path $(ANCHOR_MANIFEST) --all --check
 
-lint: ## Clippy the workspace and check the excluded anchor example
+lint: ## Clippy the workspace, hydra's optional features, and the anchor example
 	cargo clippy --workspace $(CLIPPY)
-	cargo check --manifest-path $(ANCHOR_MANIFEST) --all-targets
+	cargo clippy -p hydra --features $(HYDRA_FEATURES) $(CLIPPY)
+	cargo clippy --manifest-path $(ANCHOR_MANIFEST) $(CLIPPY)
 
 # ---------------------------------------------------------------------------
 # Test. `hydra-tests` and the example mollusk tests load the compiled .so
@@ -74,16 +77,16 @@ lint: ## Clippy the workspace and check the excluded anchor example
 # ---------------------------------------------------------------------------
 .PHONY: test test-examples test-anchor test-all bench cu-table
 
-test: build ## Run the hydra-tests suite (unit + integration, via nextest)
-	cargo nextest run -p hydra-tests
+test: build build-examples ## Run every workspace test (via nextest)
+	cargo nextest run --workspace
 
-test-examples: build build-examples ## Run the native + pinocchio example mollusk tests
+test-examples: build build-examples ## Run just the native + pinocchio example mollusk tests
 	cargo nextest run -p hydra-example-native -p hydra-example-pinocchio
 
 test-anchor: build build-anchor ## Run the anchor example mollusk test (needs the anchor CLI)
 	cd examples/anchor && anchor run test
 
-test-all: test test-examples test-anchor ## Run hydra-tests and every example mollusk test
+test-all: test test-anchor ## Run the workspace tests plus the anchor example test
 
 bench: build ## Run the compute-unit benchmarks
 	cargo bench -p hydra-tests

--- a/Makefile
+++ b/Makefile
@@ -53,11 +53,13 @@ build-anchor: ## anchor build the anchor example (needs the anchor CLI)
 # ---------------------------------------------------------------------------
 .PHONY: fmt fmt-check lint
 
-fmt: ## Format the workspace
+fmt: ## Format the workspace and the excluded anchor example
 	cargo fmt --all
+	cargo fmt --manifest-path $(ANCHOR_MANIFEST) --all
 
 fmt-check: ## Check formatting without writing (CI)
 	cargo fmt --all --check
+	cargo fmt --manifest-path $(ANCHOR_MANIFEST) --all --check
 
 lint: ## Clippy the workspace and check the excluded anchor example
 	cargo clippy --workspace $(CLIPPY)

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@
 # Toolchain prerequisites:
 #   - Rust + `cargo build-sbf` (Solana/Anza toolchain)
 #   - cargo-nextest         -> `make install-tools`
-#   - anchor CLI            -> only for `make build-examples`
+#   - anchor CLI            -> only for `make build-anchor` / `make test-anchor`
 
 SHELL := /bin/bash
 .DEFAULT_GOAL := help
@@ -32,7 +32,7 @@ help: ## Show this help
 # ---------------------------------------------------------------------------
 # Build — on-chain SBF programs (artifacts land in target/deploy/*.so).
 # ---------------------------------------------------------------------------
-.PHONY: build build-examples
+.PHONY: build build-examples build-anchor
 
 build: ## build-sbf the noop + base + ephemeral hydra programs
 	cargo build-sbf --manifest-path $(NOOP_MANIFEST)
@@ -41,7 +41,12 @@ build: ## build-sbf the noop + base + ephemeral hydra programs
 build-examples: ## build-sbf the native + pinocchio example programs
 	cargo build-sbf --manifest-path $(NATIVE_MANIFEST)
 	cargo build-sbf --manifest-path $(PINOCCHIO_MANIFEST)
-	cd examples/anchor && anchor build
+
+# `--ignore-keys`: anchor >=1.0 refuses to build when target/deploy's keypair
+# doesn't match `declare_id!`, and that keypair is generated per-machine. The
+# example is mollusk-only (never deployed), so the on-disk keypair is moot.
+build-anchor: ## anchor build the anchor example (needs the anchor CLI)
+	cd examples/anchor && anchor build --ignore-keys
 
 # ---------------------------------------------------------------------------
 # Format & lint (mirrors the fmt + default CI jobs).
@@ -62,7 +67,7 @@ lint: ## Clippy the workspace and check the excluded anchor example
 # Test. `hydra-tests` and the example mollusk tests load the compiled .so
 # files at runtime, so the build targets are prerequisites.
 # ---------------------------------------------------------------------------
-.PHONY: test test-examples test-all bench cu-table
+.PHONY: test test-examples test-anchor test-all bench cu-table
 
 test: build ## Run the hydra-tests suite (unit + integration, via nextest)
 	cargo nextest run -p hydra-tests
@@ -70,7 +75,10 @@ test: build ## Run the hydra-tests suite (unit + integration, via nextest)
 test-examples: build build-examples ## Run the native + pinocchio example mollusk tests
 	cargo nextest run -p hydra-example-native -p hydra-example-pinocchio
 
-test-all: test test-examples ## Run hydra-tests and the example mollusk tests
+test-anchor: build build-anchor ## Run the anchor example mollusk test (needs the anchor CLI)
+	cd examples/anchor && anchor run test
+
+test-all: test test-examples test-anchor ## Run hydra-tests and every example mollusk test
 
 bench: build ## Run the compute-unit benchmarks
 	cargo bench -p hydra-tests
@@ -83,7 +91,7 @@ cu-table: build ## Print the per-instruction CU table (the ignored cu_table test
 # ---------------------------------------------------------------------------
 .PHONY: ci install-tools clean
 
-ci: fmt-check lint build test ## Run the default CI job locally (fmt-check + lint + build + test)
+ci: fmt-check lint build test-all ## Run the default CI job locally (fmt-check + lint + build + test-all)
 
 install-tools: ## Install cargo-nextest (Solana/anchor/node toolchains are installed separately)
 	cargo install cargo-nextest --locked

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,92 @@
+# Hydra — build & test commands.
+#
+# Quickstart:
+#   make build   # compile the on-chain programs (needed before tests)
+#   make test    # run the hydra-tests suite
+#   make ci      # everything the default CI job runs, locally
+#
+# Run `make` or `make help` for the full list.
+#
+# Toolchain prerequisites:
+#   - Rust + `cargo build-sbf` (Solana/Anza toolchain)
+#   - cargo-nextest         -> `make install-tools`
+#   - anchor CLI            -> only for `make build-examples`
+
+SHELL := /bin/bash
+.DEFAULT_GOAL := help
+
+# Manifests for the crates that live outside the default workspace build.
+BASE_MANIFEST     := programs/hydra/Cargo.toml
+NOOP_MANIFEST      := tests/programs/noop/Cargo.toml
+NATIVE_MANIFEST    := examples/native/Cargo.toml
+PINOCCHIO_MANIFEST := examples/pinocchio/Cargo.toml
+ANCHOR_MANIFEST    := examples/anchor/Cargo.toml
+
+CLIPPY := --all-targets -- -D warnings
+
+.PHONY: help
+help: ## Show this help
+	@grep -hE '^[a-zA-Z0-9_-]+:.*?## ' $(MAKEFILE_LIST) \
+		| awk 'BEGIN{FS=":.*?## "}{printf "  \033[36m%-16s\033[0m %s\n", $$1, $$2}'
+
+# ---------------------------------------------------------------------------
+# Build — on-chain SBF programs (artifacts land in target/deploy/*.so).
+# ---------------------------------------------------------------------------
+.PHONY: build build-examples
+
+build: ## build-sbf the noop + base + ephemeral hydra programs
+	cargo build-sbf --manifest-path $(NOOP_MANIFEST)
+	cargo build-sbf --manifest-path $(BASE_MANIFEST)
+
+build-examples: ## build-sbf the native + pinocchio example programs
+	cargo build-sbf --manifest-path $(NATIVE_MANIFEST)
+	cargo build-sbf --manifest-path $(PINOCCHIO_MANIFEST)
+	cd examples/anchor && anchor build
+
+# ---------------------------------------------------------------------------
+# Format & lint (mirrors the fmt + default CI jobs).
+# ---------------------------------------------------------------------------
+.PHONY: fmt fmt-check lint
+
+fmt: ## Format the workspace
+	cargo fmt --all
+
+fmt-check: ## Check formatting without writing (CI)
+	cargo fmt --all --check
+
+lint: ## Clippy the workspace and check the excluded anchor example
+	cargo clippy --workspace $(CLIPPY)
+	cargo check --manifest-path $(ANCHOR_MANIFEST) --all-targets
+
+# ---------------------------------------------------------------------------
+# Test. `hydra-tests` and the example mollusk tests load the compiled .so
+# files at runtime, so the build targets are prerequisites.
+# ---------------------------------------------------------------------------
+.PHONY: test test-examples test-all bench cu-table
+
+test: build ## Run the hydra-tests suite (unit + integration, via nextest)
+	cargo nextest run -p hydra-tests
+
+test-examples: build build-examples ## Run the native + pinocchio example mollusk tests
+	cargo nextest run -p hydra-example-native -p hydra-example-pinocchio
+
+test-all: test test-examples ## Run hydra-tests and the example mollusk tests
+
+bench: build ## Run the compute-unit benchmarks
+	cargo bench -p hydra-tests
+
+cu-table: build ## Print the per-instruction CU table (the ignored cu_table test)
+	cargo test -p hydra-tests cu_table -- --ignored --nocapture
+
+# ---------------------------------------------------------------------------
+# Aggregate / housekeeping.
+# ---------------------------------------------------------------------------
+.PHONY: ci install-tools clean
+
+ci: fmt-check lint build test ## Run the default CI job locally (fmt-check + lint + build + test)
+
+install-tools: ## Install cargo-nextest (Solana/anchor/node toolchains are installed separately)
+	cargo install cargo-nextest --locked
+
+clean: ## Remove Cargo build artifacts
+	cargo clean

--- a/crates/hydra-api/src/state.rs
+++ b/crates/hydra-api/src/state.rs
@@ -187,7 +187,11 @@ pub unsafe fn load_crank_mut(bytes: &mut [u8]) -> Result<&mut Crank, ProgramErro
 #[inline]
 pub fn find_crank_pda(payer: &[u8; 32], seed: &[u8; 32]) -> (solana_address::Address, u8) {
     solana_address::Address::find_program_address(
-        &[crate::consts::CRANK_SEED_PREFIX, payer.as_ref(), seed.as_ref()],
+        &[
+            crate::consts::CRANK_SEED_PREFIX,
+            payer.as_ref(),
+            seed.as_ref(),
+        ],
         &crate::ID,
     )
 }

--- a/examples/anchor/Anchor.toml
+++ b/examples/anchor/Anchor.toml
@@ -1,5 +1,5 @@
 [toolchain]
-anchor_version = "1.0.0"
+anchor_version = "1.0.2"
 
 [features]
 resolution = true

--- a/examples/anchor/Anchor.toml
+++ b/examples/anchor/Anchor.toml
@@ -5,26 +5,17 @@ anchor_version = "1.0.0"
 resolution = true
 skip-lint = false
 
-[programs.localnet]
-hydra_example_anchor = "Xyj597GykzwSu44muqNHtYs2aKUgm9ydNoHNySTDFs5"
-
 [programs.devnet]
 hydra_example_anchor = "Xyj597GykzwSu44muqNHtYs2aKUgm9ydNoHNySTDFs5"
 
-[registry]
-url = "https://api.apr.dev"
+[programs.localnet]
+hydra_example_anchor = "rgMuTEnEYWEK3EzqH9MkFthU9shDAPLgZX7dztEbBf4"
 
 [provider]
-cluster = "Localnet"
+cluster = "localnet"
 wallet = "~/.config/solana/id.json"
 
 [scripts]
-# The mollusk test lives inside the program crate (tests/mollusk.rs).
-# Mollusk runs in-process — no validator, no deploy — so invoke via:
-#
-#   anchor test --skip-local-validator --skip-deploy
-#
-# (Plain `anchor test` spins up a local validator and tries to deploy,
-#  which is unnecessary; adding those two flags makes Anchor skip both
-#  and just run this script.)
 test = "cargo test --manifest-path programs/hydra-example-anchor/Cargo.toml --test mollusk -- --nocapture"
+
+[hooks]

--- a/examples/anchor/programs/hydra-example-anchor/Cargo.toml
+++ b/examples/anchor/programs/hydra-example-anchor/Cargo.toml
@@ -17,6 +17,9 @@ no-entrypoint = []
 no-idl = []
 no-log-ix-name = []
 idl-build = ["anchor-lang/idl-build"]
+anchor-debug = []
+custom-panic = []
+custom-heap = []
 
 [dependencies]
 anchor-lang = "1.0"
@@ -34,3 +37,8 @@ solana-instruction = "3"
 solana-pubkey = "4"
 # Host-side builders + PDA helpers.
 hydra-api = { path = "../../../../crates/hydra-api", features = ["client"] }
+
+[lints.rust.unexpected_cfgs]
+level = "warn"
+priority = 0
+check-cfg = ['cfg(target_os, values("solana"))']

--- a/examples/anchor/programs/hydra-example-anchor/tests/mollusk.rs
+++ b/examples/anchor/programs/hydra-example-anchor/tests/mollusk.rs
@@ -20,7 +20,9 @@ use solana_account::Account;
 use solana_instruction::{AccountMeta, Instruction};
 use solana_pubkey::Pubkey;
 
-use hydra_example_anchor::{accounts as schedule_accts, instruction as schedule_ix, ID as EXAMPLE_ID};
+use hydra_example_anchor::{
+    accounts as schedule_accts, instruction as schedule_ix, ID as EXAMPLE_ID,
+};
 
 /// Path to the Anchor example `.so` (without extension), relative to this
 /// crate's `CARGO_MANIFEST_DIR`.
@@ -96,8 +98,7 @@ fn schedule_creates_crank_via_cpi_into_hydra() {
     };
 
     let hydra_elf = std::fs::read(format!("{HYDRA_SO}.so")).expect("read hydra .so");
-    let hydra_program_acct =
-        mollusk_svm::program::create_program_account_loader_v2(&hydra_elf);
+    let hydra_program_acct = mollusk_svm::program::create_program_account_loader_v2(&hydra_elf);
 
     let accounts = vec![
         (payer, Account::new(1_000_000_000, 0, &system_program)),

--- a/examples/anchor/programs/hydra-example-anchor/tests/mollusk.rs
+++ b/examples/anchor/programs/hydra-example-anchor/tests/mollusk.rs
@@ -41,21 +41,28 @@ fn hydra_id() -> Pubkey {
     Pubkey::new_from_array(hydra_api::ID.to_bytes())
 }
 
+fn require_so(path: &str, how_to_build: &str) -> bool {
+    if std::path::Path::new(&format!("{path}.so")).exists() {
+        return true;
+    }
+    assert!(
+        std::env::var_os("CI").is_none(),
+        "{path}.so not found. {how_to_build}"
+    );
+    eprintln!("skipping: {path}.so not found. {how_to_build}");
+    false
+}
+
 #[test]
 fn schedule_creates_crank_via_cpi_into_hydra() {
-    // Skip gracefully if prerequisites aren't built yet.
-    if !std::path::Path::new(&format!("{HYDRA_SO}.so")).exists() {
-        eprintln!(
-            "skipping: {HYDRA_SO}.so not found. \
-             Run `cargo build-sbf` on the root Hydra workspace first."
-        );
+    // Skip gracefully if prerequisites aren't built yet (locally only).
+    if !require_so(
+        HYDRA_SO,
+        "Run `cargo build-sbf` on the root Hydra workspace first.",
+    ) {
         return;
     }
-    if !std::path::Path::new(&format!("{EXAMPLE_SO}.so")).exists() {
-        eprintln!(
-            "skipping: {EXAMPLE_SO}.so not found. \
-             Run `anchor build` in examples/anchor first."
-        );
+    if !require_so(EXAMPLE_SO, "Run `anchor build` in examples/anchor first.") {
         return;
     }
 

--- a/examples/native/tests/mollusk.rs
+++ b/examples/native/tests/mollusk.rs
@@ -27,16 +27,24 @@ fn hydra_id() -> Pubkey {
     Pubkey::new_from_array(hydra_api::ID.to_bytes())
 }
 
+fn require_so(path: &str, how_to_build: &str) -> bool {
+    if std::path::Path::new(&format!("{path}.so")).exists() {
+        return true;
+    }
+    assert!(
+        std::env::var_os("CI").is_none(),
+        "{path}.so not found. {how_to_build}"
+    );
+    eprintln!("skipping: {path}.so not found. {how_to_build}");
+    false
+}
+
 #[test]
 fn schedule_creates_crank_via_cpi_into_hydra() {
-    if !std::path::Path::new(&format!("{HYDRA_SO}.so")).exists() {
-        eprintln!(
-            "skipping: {HYDRA_SO}.so not found. Run `cargo build-sbf` on the Hydra workspace."
-        );
+    if !require_so(HYDRA_SO, "Run `cargo build-sbf` on the Hydra workspace.") {
         return;
     }
-    if !std::path::Path::new(&format!("{EXAMPLE_SO}.so")).exists() {
-        eprintln!("skipping: {EXAMPLE_SO}.so not found. Run `cargo build-sbf` on this crate.");
+    if !require_so(EXAMPLE_SO, "Run `cargo build-sbf` on this crate.") {
         return;
     }
     let mut mollusk = Mollusk::new(&EXAMPLE_ID, EXAMPLE_SO);

--- a/examples/pinocchio/tests/mollusk.rs
+++ b/examples/pinocchio/tests/mollusk.rs
@@ -30,16 +30,24 @@ fn hydra_id() -> Pubkey {
     Pubkey::new_from_array(hydra_api::ID.to_bytes())
 }
 
+fn require_so(path: &str, how_to_build: &str) -> bool {
+    if std::path::Path::new(&format!("{path}.so")).exists() {
+        return true;
+    }
+    assert!(
+        std::env::var_os("CI").is_none(),
+        "{path}.so not found. {how_to_build}"
+    );
+    eprintln!("skipping: {path}.so not found. {how_to_build}");
+    false
+}
+
 #[test]
 fn schedule_creates_crank_via_cpi_into_hydra() {
-    if !std::path::Path::new(&format!("{HYDRA_SO}.so")).exists() {
-        eprintln!(
-            "skipping: {HYDRA_SO}.so not found. Run `cargo build-sbf` on the Hydra workspace."
-        );
+    if !require_so(HYDRA_SO, "Run `cargo build-sbf` on the Hydra workspace.") {
         return;
     }
-    if !std::path::Path::new(&format!("{EXAMPLE_SO}.so")).exists() {
-        eprintln!("skipping: {EXAMPLE_SO}.so not found. Run `cargo build-sbf` on this crate.");
+    if !require_so(EXAMPLE_SO, "Run `cargo build-sbf` on this crate.") {
         return;
     }
 

--- a/programs/hydra/src/entrypoint.rs
+++ b/programs/hydra/src/entrypoint.rs
@@ -66,12 +66,12 @@ fn log_error(_error: &ProgramError) {
         // `to_str` is an inherent method on `ProgramError` that internally
         // calls `HydraError::to_str` (defined in hydra-api::error) for
         // `ProgramError::Custom(n)` values.
-        let msg: &'static str = _error.to_str::<HydraError>();
+        let _msg: &'static str = _error.to_str::<HydraError>();
         #[cfg(target_os = "solana")]
         // SAFETY: sol_log_ takes (ptr, len) of a byte buffer the syscall
         // reads read-only for the duration of the call.
         unsafe {
-            solana_define_syscall::definitions::sol_log_(msg.as_ptr(), msg.len() as u64);
+            solana_define_syscall::definitions::sol_log_(_msg.as_ptr(), _msg.len() as u64);
         }
     }
 }


### PR DESCRIPTION
Closes #21

Adds a Makefile and CI jobs

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated CI checks for formatting, linting, builds, and tests.
  * Added a Makefile with commands for development, testing, benchmarking, and cleanup.
  * Improved Anchor configuration for localnet and devnet workflows.

* **Bug Fixes**
  * Missing compiled program artifacts now skip local tests gracefully and fail clearly in CI.

* **Chores**
  * Updated project ignore rules and Rust configuration for more consistent builds and validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->