### PR TITLE
chore: use sdk v0.17

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,18 +25,26 @@ repository = "https://github.com/magicblock-labs/hydra"
 pinocchio = { version = "0.11", features = ["cpi"] }
 pinocchio-system = "0.6"
 pinocchio-log = "0.5"
-solana-address = { version = "2.6", features = ["decode", "curve25519"] }
+ephemeral-rollups-pinocchio = "0.17"
+solana-address = { version = "2", features = ["decode", "curve25519"] }
 solana-define-syscall = "5.0"
 hydra-api = { path = "crates/hydra-api" }
 
 # tests only:
 mollusk-svm = "=0.12.1-agave-4.0"
 mollusk-svm-programs-memo = "=0.12.1-agave-4.0"
-solana-svm-log-collector = { version = "4.0.0-beta", features = ["agave-unstable-api"] }
+solana-svm-log-collector = { version = "4.0.0-beta", features = [
+    "agave-unstable-api",
+] }
 solana-logger = "3"
 solana-account = "3.0"
 solana-instruction = "3.0"
 solana-pubkey = "4.0"
+solana-keypair = "3.1"
+solana-message = "3.0.1"
+solana-signer = "3.0"
+solana-transaction = "3.0"
+solana-hash = "3.1.0"
 solana-system-interface = { version = "2.0", features = ["bincode"] }
 
 [profile.release]
@@ -47,5 +55,4 @@ overflow-checks = true
 [workspace.lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = [
     'cfg(target_os, values("solana"))',
-    'cfg(feature, values("create-account-allow-prefund", "custom-alloc", "custom-panic", "no-entrypoint", "logging"))',
 ] }


### PR DESCRIPTION
Closes #22

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated internal package configuration and supporting libraries.
  * Added support for ephemeral rollups and Solana transaction-related functionality.
  * Updated the Solana address package and refreshed feature configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->