### PR TITLE
refactor: move shared crank logic into hydra-api::program

### DIFF
--- a/crates/hydra-api/Cargo.toml
+++ b/crates/hydra-api/Cargo.toml
@@ -24,10 +24,16 @@ cpi-native = [
 # `pinocchio::cpi::invoke_signed` with `InstructionView`s built on the
 # stack (no allocations, usable from `no_std` programs).
 cpi-pinocchio = ["pinocchio/cpi"]
+# Shared on-chain processor building blocks (schedule parsing, tail
+# serialization, follow-up verification, sysvar syscalls) consumed by the
+# `programs/hydra` and `programs/hydra-ephemeral` program crates. Pulls in
+# `solana-define-syscall` for the raw Clock / stack-height reads.
+program = ["pinocchio/cpi", "dep:solana-define-syscall"]
 
 [dependencies]
 pinocchio = { workspace = true }
 solana-address = { workspace = true }
+solana-define-syscall = { workspace = true, optional = true }
 solana-instruction = { workspace = true, optional = true }
 solana-pubkey = { workspace = true, optional = true }
 solana-account-info = { version = "3", optional = true }

--- a/crates/hydra-api/src/lib.rs
+++ b/crates/hydra-api/src/lib.rs
@@ -10,6 +10,8 @@ pub mod consts;
 pub mod cpi;
 pub mod error;
 pub mod instruction;
+#[cfg(feature = "program")]
+pub mod program;
 pub mod state;
 
 pub use consts::*;

--- a/crates/hydra-api/src/program/helpers.rs
+++ b/crates/hydra-api/src/program/helpers.rs
@@ -1,4 +1,4 @@
-//! Tiny utilities that don't fit into any one processor.
+//! Tiny syscall utilities shared by the on-chain processors.
 
 use pinocchio::error::ProgramError;
 #[cfg(target_os = "solana")]

--- a/crates/hydra-api/src/program/mod.rs
+++ b/crates/hydra-api/src/program/mod.rs
@@ -1,0 +1,11 @@
+//! On-chain building blocks shared by the base-layer and ephemeral-rollup Hydra
+//! programs. Gated behind the `program` feature so client/CPI consumers don't
+//! pull the pinocchio-flavoured processor code (or `solana-define-syscall`).
+//!
+//! Each program crate (`programs/hydra`, `programs/hydra-ephemeral`) keeps only
+//! its CPI-funding-model-specific handlers; everything that is identical across
+//! the two ledgers — schedule parsing, tail serialization, follow-up
+//! verification, the sysvar syscalls — lives here.
+
+pub mod helpers;
+pub mod processor;

--- a/crates/hydra-api/src/program/processor.rs
+++ b/crates/hydra-api/src/program/processor.rs
@@ -1,0 +1,503 @@
+//! Shared helpers for the on-chain crank processors (base + ephemeral).
+//!
+//! These building blocks are program-agnostic: every function that needs the
+//! caller's program id takes it as a parameter, so both the base-layer and the
+//! ephemeral-rollup programs link the exact same code here.
+
+use pinocchio::{error::ProgramError, AccountView, Address, ProgramResult};
+
+use crate::{
+    consts::{
+        self, MAX_ACCOUNTS, MAX_COMPUTE_UNIT_LIMIT, MAX_DATA_LEN, MAX_INSTRUCTIONS,
+        META_FLAG_SIGNER, REMAINING_INFINITE, SERIALIZED_META_SIZE,
+    },
+    instruction::{CREATE_FIXED_PREFIX_LEN, CREATE_IX_HEADER_LEN},
+    program::helpers::get_clock_slot,
+    state::{
+        find_crank_pda_unscoped_with_program_id, find_crank_pda_with_program_id, load_crank,
+        load_crank_mut, Crank,
+    },
+    HydraError, CRANK_HEADER_SIZE,
+};
+
+/// `signer` must sign and `crank` must be Hydra-owned — the preamble of every
+/// `Cancel` / `Close` path.
+pub fn require_signed_crank(
+    signer: &AccountView,
+    crank_ai: &AccountView,
+    program_id: &Address,
+) -> ProgramResult {
+    if !signer.is_signer() {
+        return Err(ProgramError::MissingRequiredSignature);
+    }
+    if !crank_ai.owned_by(program_id) {
+        return Err(ProgramError::InvalidAccountOwner);
+    }
+    Ok(())
+}
+
+/// Anti-grief: when a crank has a non-zero authority, only that authority may
+/// receive the rent refund. Shared by base and ephemeral `Close`.
+pub fn require_refund_recipient(
+    stored_authority: [u8; 32],
+    recipient: &AccountView,
+) -> ProgramResult {
+    if stored_authority != [0u8; 32] && recipient.address().as_array() != &stored_authority {
+        return Err(HydraError::UnauthorizedAuthority.into());
+    }
+    Ok(())
+}
+
+/// Authority-gated close preamble shared by base `Cancel` and `CancelEphemeral`:
+/// `authority` signs a Hydra-owned crank and matches its stored (non-zero)
+/// authority.
+pub fn require_cancel_authority(
+    authority: &AccountView,
+    crank_ai: &AccountView,
+    program_id: &Address,
+) -> ProgramResult {
+    require_signed_crank(authority, crank_ai, program_id)?;
+    let stored = {
+        let data = crank_ai.try_borrow()?;
+        unsafe { load_crank(&data)? }.authority
+    };
+    if stored == [0u8; 32] || authority.address().as_array() != &stored {
+        return Err(HydraError::UnauthorizedAuthority.into());
+    }
+    Ok(())
+}
+
+/// The fixed-size scheduling prefix of a `Create` / `CreateEphemeral` payload.
+/// `next_exec` / `interval` are slot counts on both ledgers — base-layer slots
+/// for base cranks, ephemeral-rollup slots for ephemeral cranks (the ER runs
+/// faster, so the same wall-clock interval is more slots). Both `Trigger`
+/// handlers compare against the ledger's own clock slot and advance
+/// `next_exec_slot` by `interval_slots`; the wire bytes are identical either way.
+pub struct CreateHeader {
+    pub seed: [u8; 32],
+    pub authority: [u8; 32],
+    pub next_exec: u64,
+    pub interval: u64,
+    pub remaining_wire: u64,
+    pub priority_tip: u64,
+    pub cu_limit: u32,
+}
+
+/// Parse + validate the fixed prefix of a `Create` payload. Requires at least
+/// the prefix plus one scheduled-ix blob header.
+pub fn parse_create_header(data: &[u8]) -> Result<CreateHeader, ProgramError> {
+    if data.len() < CREATE_FIXED_PREFIX_LEN + CREATE_IX_HEADER_LEN {
+        return Err(ProgramError::InvalidInstructionData);
+    }
+    // SAFETY: bounds checked above; the reads only require byte alignment.
+    let header = CreateHeader {
+        seed: unsafe { *(data.as_ptr() as *const [u8; 32]) },
+        authority: unsafe { *(data.as_ptr().add(32) as *const [u8; 32]) },
+        next_exec: read_u64_le(data, 64),
+        interval: read_u64_le(data, 72),
+        remaining_wire: read_u64_le(data, 80),
+        priority_tip: read_u64_le(data, 88),
+        cu_limit: read_u32_le(data, 96),
+    };
+    // `0` opts out of `SetComputeUnitLimit`; non-zero must fit the per-tx ceiling.
+    if header.cu_limit > MAX_COMPUTE_UNIT_LIMIT {
+        return Err(HydraError::InvalidSchedule.into());
+    }
+    // A never-advancing infinite crank makes no sense.
+    if header.remaining_wire == 0 && header.interval == 0 {
+        return Err(HydraError::InvalidSchedule.into());
+    }
+    Ok(header)
+}
+
+/// Write the parsed prefix + computed fields into a freshly-allocated crank
+/// header. `rent_min` is the cached rent floor for base cranks and `0` for
+/// ephemeral cranks (which hold no lamports).
+#[inline(always)]
+pub fn write_header(
+    state: &mut Crank,
+    h: &CreateHeader,
+    bump: u8,
+    authority_signer: u8,
+    rent_min: u64,
+    region_len: u16,
+) {
+    state.authority = h.authority;
+    state.seed = h.seed;
+    state.set_next_exec_slot(h.next_exec);
+    state.set_interval_slots(h.interval);
+    state.set_remaining(if h.remaining_wire == 0 {
+        REMAINING_INFINITE
+    } else {
+        h.remaining_wire
+    });
+    state.set_priority_tip(h.priority_tip);
+    state.set_executed(0);
+    state.set_rent_min(rent_min);
+    state.set_region_len(region_len);
+    state.bump = bump;
+    state.set_cu_limit(h.cu_limit);
+    state.authority_signer = authority_signer;
+}
+
+/// The scheduled-ix tail must fit `Crank.region_len` (a `u16`).
+const MAX_REGION_LEN: usize = u16::MAX as usize;
+
+/// Measure the exact tail length the scheduled ixs serialize to, validating the
+/// per-ix structure, the instruction-count limit, and the `region_len` ceiling
+/// in a single pass. Mirrors the byte accounting in [`write_tail`] so the caller
+/// can allocate the precise account size up front; `write_tail` then re-validates
+/// (incl. signer flags) and writes, yielding the same length.
+pub fn measure_region(data: &[u8]) -> Result<usize, ProgramError> {
+    let mut cursor = CREATE_FIXED_PREFIX_LEN;
+    let mut region_len = 0usize;
+    let mut num_instructions = 0usize;
+
+    while cursor < data.len() {
+        let (num_accounts, data_len, next) = parse_ix_header(data, cursor)?;
+        num_instructions += 1;
+        if num_instructions > MAX_INSTRUCTIONS {
+            return Err(HydraError::InvalidSchedule.into());
+        }
+        let metas_len = num_accounts * SERIALIZED_META_SIZE;
+        // [num_accounts u16][metas][program_id 32][data_len u16][data]
+        region_len += 2 + metas_len + 32 + 2 + data_len;
+        cursor = next;
+    }
+
+    if region_len > MAX_REGION_LEN {
+        return Err(HydraError::InvalidSchedule.into());
+    }
+    Ok(region_len)
+}
+
+/// Derive the crank PDA and verify it matches the supplied account,
+/// returning the bump for the create CPI's signer seeds.
+/// Shared by both `Create` paths.
+pub fn derive_crank_pda(
+    crank_ai: &AccountView,
+    payer: &[u8; 32],
+    seed: &[u8; 32],
+    program_id: &Address,
+) -> Result<(u8, bool), ProgramError> {
+    // Derive the payer-bound PDA (`[b"crank", payer, seed]`) — squat-proof:
+    // a different payer derives a different address.
+    let (expected_pda, bump) = find_crank_pda_with_program_id(payer, seed, program_id);
+    let payer_bound = crank_ai.address() == &expected_pda;
+    // DEPRECATED: legacy unscoped derivation (`[b"crank", seed]`) is squattable.
+    // TODO: remove this fallback once all integrators are on payer-bound PDAs.
+    let bump = if payer_bound {
+        bump
+    } else {
+        let (legacy_pda, legacy_bump) = find_crank_pda_unscoped_with_program_id(seed, program_id);
+        if crank_ai.address() != &legacy_pda {
+            return Err(ProgramError::InvalidSeeds);
+        }
+        legacy_bump
+    };
+    Ok((bump, payer_bound))
+}
+
+/// Finalize a freshly-allocated crank account: serialize the scheduled-ix tail
+/// and write the header. The account must already be sized to
+/// `CRANK_HEADER_SIZE + region_len`; `rent_min` is the cached rent floor for base
+/// cranks and `0` for ephemeral cranks (which hold no lamports). Shared by both
+/// `Create` paths.
+pub fn write_crank(
+    crank_ai: &mut AccountView,
+    data: &[u8],
+    header: &CreateHeader,
+    bump: u8,
+    authority_signer: u8,
+    rent_min: u64,
+    region_len: usize,
+) -> ProgramResult {
+    let mut account_data = crank_ai.try_borrow_mut()?;
+    let buf: &mut [u8] = &mut account_data;
+    if buf.len() < CRANK_HEADER_SIZE {
+        return Err(ProgramError::AccountDataTooSmall);
+    }
+    let (header_bytes, tail_bytes) = buf.split_at_mut(CRANK_HEADER_SIZE);
+
+    let written = write_tail(tail_bytes, data)?;
+    if written != region_len {
+        return Err(HydraError::InvalidSchedule.into());
+    }
+
+    // SAFETY: split yields CRANK_HEADER_SIZE bytes; Crank is align-1 (compile-time checked).
+    let state = unsafe { load_crank_mut(header_bytes)? };
+    write_header(
+        state,
+        header,
+        bump,
+        authority_signer,
+        rent_min,
+        region_len as u16,
+    );
+    Ok(())
+}
+
+/// Validate + serialize the scheduled ixs of a `Create` payload into `tail`,
+/// returning the bytes written. Every write is bounds-checked against
+/// `tail.len()` so a wrongly-sized account fails cleanly instead of writing out
+/// of bounds.
+///
+/// Mirrors the tail layout produced by `processor::create` — see that file for
+/// the wire format. Kept separate so the audited base path stays untouched.
+pub fn write_tail(tail: &mut [u8], data: &[u8]) -> Result<usize, ProgramError> {
+    let cap = tail.len();
+    let mut cursor = CREATE_FIXED_PREFIX_LEN;
+    let mut off = 0usize;
+    let mut num_instructions = 0usize;
+
+    while cursor < data.len() {
+        let (num_accounts, data_len, next) = parse_ix_header(data, cursor)?;
+        num_instructions += 1;
+        if num_instructions > MAX_INSTRUCTIONS {
+            return Err(HydraError::InvalidSchedule.into());
+        }
+        let metas_offset = cursor + CREATE_IX_HEADER_LEN;
+        let metas_len = num_accounts * SERIALIZED_META_SIZE;
+        let data_offset = metas_offset + metas_len;
+        // For each meta: reject signer flags (scheduled ixs run top-level and
+        // can only be signed by real keys, which this program can't produce),
+        // and fold the account into the writability-conflict tracker.
+        for account_index in 0..num_accounts {
+            let meta_offset = metas_offset + account_index * SERIALIZED_META_SIZE;
+            let meta_flag = data[meta_offset];
+            if meta_flag & META_FLAG_SIGNER != 0 {
+                return Err(HydraError::SignerInScheduledIx.into());
+            }
+        }
+
+        // [num_accounts u16][metas][program_id 32][data_len u16][data]
+        let blob_len = 2 + metas_len + 32 + 2 + data_len;
+        if off + blob_len > cap {
+            return Err(ProgramError::AccountDataTooSmall);
+        }
+        tail[off..off + 2].copy_from_slice(&(num_accounts as u16).to_le_bytes());
+        off += 2;
+        tail[off..off + metas_len].copy_from_slice(&data[metas_offset..data_offset]);
+        off += metas_len;
+        tail[off..off + 32].copy_from_slice(&data[cursor + 3..cursor + CREATE_IX_HEADER_LEN]);
+        off += 32;
+        tail[off..off + 2].copy_from_slice(&(data_len as u16).to_le_bytes());
+        off += 2;
+        tail[off..off + data_len].copy_from_slice(&data[data_offset..next]);
+        off += data_len;
+
+        cursor = next;
+    }
+
+    Ok(off)
+}
+
+/// Parse one scheduled-ix blob header at `cursor`, validating limits and bounds.
+/// Returns `(num_accounts, data_len, next_cursor)`.
+#[inline(always)]
+pub fn parse_ix_header(data: &[u8], cursor: usize) -> Result<(usize, usize, usize), ProgramError> {
+    if cursor + CREATE_IX_HEADER_LEN > data.len() {
+        return Err(ProgramError::InvalidInstructionData);
+    }
+    let num_accounts = data[cursor] as usize;
+    let data_len = u16::from_le_bytes([data[cursor + 1], data[cursor + 2]]) as usize;
+    if num_accounts > MAX_ACCOUNTS || data_len > MAX_DATA_LEN {
+        return Err(HydraError::InvalidSchedule.into());
+    }
+    let metas_len = num_accounts * SERIALIZED_META_SIZE;
+    let next = cursor + CREATE_IX_HEADER_LEN + metas_len + data_len;
+    if next > data.len() {
+        return Err(ProgramError::InvalidInstructionData);
+    }
+    Ok((num_accounts, data_len, next))
+}
+
+/// Parse the instructions sysvar, locate the region for
+/// `current_ix_index + 1`, and byte-compare it against the crank's stored tail.
+///
+/// Shared with the ephemeral-rollup `TriggerEphemeral` handler — the
+/// follow-up binding is identical on both ledgers.
+#[inline(always)]
+pub fn verify_followup(
+    sysvar: &AccountView,
+    crank: &AccountView,
+    region_len: usize,
+) -> ProgramResult {
+    // SAFETY: we're in a linear entrypoint flow with no outstanding borrows
+    // on either account. pinocchio's `borrow_unchecked` skips the refcell
+    // bookkeeping, which saves a handful of CUs per call.
+    let sv: &[u8] = unsafe { sysvar.borrow_unchecked() };
+    let cr: &[u8] = unsafe { crank.borrow_unchecked() };
+
+    let sv_len = sv.len();
+    if sv_len < 4 {
+        return Err(ProgramError::InvalidAccountData);
+    }
+
+    // [len-2..len] = current_ix_index (u16 LE)
+    let current = unsafe { read_u16(sv.as_ptr().add(sv_len - 2)) } as usize;
+    let target = current
+        .checked_add(1)
+        .ok_or(HydraError::MissingFollowupInstruction)?;
+
+    // [0..2] = num_instructions (u16 LE)
+    let num_ix = unsafe { read_u16(sv.as_ptr()) } as usize;
+    if target >= num_ix {
+        return Err(HydraError::MissingFollowupInstruction.into());
+    }
+
+    // [2 + 2*target..+2] = offset of instruction `target`'s region.
+    let off_pos = 2 + 2 * target;
+    if off_pos + 2 > sv_len {
+        return Err(ProgramError::InvalidAccountData);
+    }
+    let region_start = unsafe { read_u16(sv.as_ptr().add(off_pos)) } as usize;
+    let region_end = region_start
+        .checked_add(region_len)
+        .ok_or(HydraError::MismatchedFollowupIx)?;
+    if region_end > sv_len.saturating_sub(2) {
+        return Err(HydraError::MismatchedFollowupIx.into());
+    }
+
+    let tail_end = CRANK_HEADER_SIZE
+        .checked_add(region_len)
+        .ok_or(ProgramError::InvalidAccountData)?;
+    if tail_end > cr.len() {
+        return Err(ProgramError::InvalidAccountData);
+    }
+    let tail = &cr[CRANK_HEADER_SIZE..tail_end];
+    let sv_region = &sv[region_start..region_end];
+
+    if sv_region != tail {
+        return Err(HydraError::MismatchedFollowupIx.into());
+    }
+    Ok(())
+}
+
+#[inline(always)]
+pub fn read_u64_le(data: &[u8], offset: usize) -> u64 {
+    // SAFETY: the caller ensures `offset + 8 <= data.len()`.
+    unsafe { u64::from_le_bytes(*(data.as_ptr().add(offset) as *const [u8; 8])) }
+}
+
+#[inline(always)]
+pub fn read_u32_le(data: &[u8], offset: usize) -> u32 {
+    // SAFETY: the caller ensures `offset + 4 <= data.len()`.
+    unsafe { u32::from_le_bytes(*(data.as_ptr().add(offset) as *const [u8; 4])) }
+}
+
+/// # Safety
+/// `p` must point to at least 2 readable bytes; the read is unaligned-safe.
+#[inline(always)]
+pub unsafe fn read_u16(p: *const u8) -> u16 {
+    core::ptr::read_unaligned(p as *const u16)
+}
+
+/// Move all lamports out of `src` into `dst`.
+#[inline(always)]
+pub fn drain_lamports(src: &mut AccountView, dst: &mut AccountView) -> ProgramResult {
+    let amount = src.lamports();
+    let new_dst = dst
+        .lamports()
+        .checked_add(amount)
+        .ok_or(ProgramError::ArithmeticOverflow)?;
+    src.set_lamports(0);
+    dst.set_lamports(new_dst);
+    Ok(())
+}
+
+/// Shared `Cancel`: authority-gated drain of the crank's full balance to
+/// `recipient`.
+pub fn process_cancel(
+    authority: &AccountView,
+    crank_ai: &mut AccountView,
+    recipient: &mut AccountView,
+    program_id: &Address,
+) -> ProgramResult {
+    require_cancel_authority(authority, crank_ai, program_id)?;
+    drain_lamports(crank_ai, recipient)
+}
+
+/// Shared `Close`: permissionless cleanup of an exhausted / underfunded / stuck
+/// crank. Pays a flat `CRANKER_REWARD` bounty to `reporter`, refunds the
+/// remaining balance to `recipient` (anti-grief: bound to the stored authority
+/// when set), and zeroes the crank.
+pub fn process_close(
+    reporter: &mut AccountView,
+    crank_ai: &mut AccountView,
+    recipient: &mut AccountView,
+    program_id: &Address,
+    is_ephemeral: bool,
+) -> ProgramResult {
+    let cranker_reward = if is_ephemeral {
+        consts::ephemeral::CRANKER_REWARD
+    } else {
+        consts::base::CRANKER_REWARD
+    };
+    let staleness_threshold_slots = if is_ephemeral {
+        consts::ephemeral::STALENESS_THRESHOLD_SLOTS
+    } else {
+        consts::base::STALENESS_THRESHOLD_SLOTS
+    };
+
+    require_signed_crank(reporter, crank_ai, program_id)?;
+
+    // Snapshot the fields we need from the crank header.
+    let (stored_authority, remaining, rent_min, priority_tip, next_exec_slot, lamports_now) = {
+        let data = crank_ai.try_borrow()?;
+        let state = unsafe { load_crank(&data)? };
+        (
+            state.authority,
+            state.remaining(),
+            state.rent_min(),
+            state.priority_tip(),
+            state.next_exec_slot(),
+            crank_ai.lamports(),
+        )
+    };
+
+    // Pre-condition: exhausted OR underfunded OR stuck.
+    let exhausted = remaining == 0;
+    let next_reward = cranker_reward
+        .checked_add(priority_tip)
+        .ok_or(ProgramError::ArithmeticOverflow)?;
+    let underfunded = lamports_now
+        < rent_min
+            .checked_add(next_reward)
+            .ok_or(ProgramError::ArithmeticOverflow)?;
+    // `next_exec_slot` only advances on *successful* `Trigger`, so persistent
+    // failure pins it in the past. `saturating_sub` makes future-scheduled
+    // cranks (`next_exec_slot > current_slot`) trivially not-stale.
+    let current_slot = get_clock_slot()?;
+    let stuck = current_slot.saturating_sub(next_exec_slot) > staleness_threshold_slots;
+
+    if !(exhausted || underfunded || stuck) {
+        return Err(HydraError::NotClosable.into());
+    }
+
+    require_refund_recipient(stored_authority, recipient)?;
+
+    // Flat bounty (2 × base fee) to whoever cranked the cleanup; the balance
+    // refunds to `recipient`. `min` handles a crank holding less than the
+    // bounty — reporter gets what's there, recipient gets nothing.
+    let bounty = cranker_reward.min(lamports_now);
+    let refund = lamports_now - bounty;
+
+    crank_ai.set_lamports(0);
+
+    let new_reporter = reporter
+        .lamports()
+        .checked_add(bounty)
+        .ok_or(ProgramError::ArithmeticOverflow)?;
+    reporter.set_lamports(new_reporter);
+
+    // When `recipient` aliases `reporter`, the write above is visible here, so
+    // adding `refund` on top preserves the sum. Distinct accounts: clean credit.
+    let new_recipient = recipient
+        .lamports()
+        .checked_add(refund)
+        .ok_or(ProgramError::ArithmeticOverflow)?;
+    recipient.set_lamports(new_recipient);
+
+    Ok(())
+}

--- a/crates/hydra-api/src/state.rs
+++ b/crates/hydra-api/src/state.rs
@@ -183,17 +183,35 @@ pub unsafe fn load_crank_mut(bytes: &mut [u8]) -> Result<&mut Crank, ProgramErro
     Ok(&mut *(bytes.as_mut_ptr() as *mut Crank))
 }
 
-/// Derive the payer-bound crank PDA: `[b"crank", payer, seed]`.
-#[inline]
-pub fn find_base_crank_pda(payer: &[u8; 32], seed: &[u8; 32]) -> (solana_address::Address, u8) {
+pub(crate) fn find_crank_pda_with_program_id(
+    payer: &[u8; 32],
+    seed: &[u8; 32],
+    program_id: &solana_address::Address,
+) -> (solana_address::Address, u8) {
     solana_address::Address::find_program_address(
         &[
             crate::consts::CRANK_SEED_PREFIX,
             payer.as_ref(),
             seed.as_ref(),
         ],
-        &crate::base::ID,
+        program_id,
     )
+}
+
+pub(crate) fn find_crank_pda_unscoped_with_program_id(
+    seed: &[u8; 32],
+    program_id: &solana_address::Address,
+) -> (solana_address::Address, u8) {
+    solana_address::Address::find_program_address(
+        &[crate::consts::CRANK_SEED_PREFIX, seed.as_ref()],
+        program_id,
+    )
+}
+
+/// Derive the payer-bound crank PDA: `[b"crank", payer, seed]`.
+#[inline]
+pub fn find_base_crank_pda(payer: &[u8; 32], seed: &[u8; 32]) -> (solana_address::Address, u8) {
+    find_crank_pda_with_program_id(payer, seed, &crate::base::ID)
 }
 
 /// Legacy unscoped derivation: `[b"crank", seed]`. Squattable by any payer.
@@ -201,10 +219,7 @@ pub fn find_base_crank_pda(payer: &[u8; 32], seed: &[u8; 32]) -> (solana_address
 #[deprecated(note = "squattable; use the payer-bound `find_base_crank_pda`")]
 #[inline]
 pub fn find_base_crank_pda_unscoped(seed: &[u8; 32]) -> (solana_address::Address, u8) {
-    solana_address::Address::find_program_address(
-        &[crate::consts::CRANK_SEED_PREFIX, seed.as_ref()],
-        &crate::base::ID,
-    )
+    find_crank_pda_unscoped_with_program_id(seed, &crate::base::ID)
 }
 
 /// Derive the payer-bound ephemeral crank PDA: `[b"crank", payer, seed]`.
@@ -213,14 +228,7 @@ pub fn find_ephemeral_base_crank_pda(
     payer: &[u8; 32],
     seed: &[u8; 32],
 ) -> (solana_address::Address, u8) {
-    solana_address::Address::find_program_address(
-        &[
-            crate::consts::CRANK_SEED_PREFIX,
-            payer.as_ref(),
-            seed.as_ref(),
-        ],
-        &crate::ephemeral::ID,
-    )
+    find_crank_pda_with_program_id(payer, seed, &crate::ephemeral::ID)
 }
 
 /// Legacy unscoped derivation: `[b"crank", seed]`. Squattable by any payer.
@@ -228,8 +236,5 @@ pub fn find_ephemeral_base_crank_pda(
 #[deprecated(note = "squattable; use the payer-bound `find_ephemeral_base_crank_pda`")]
 #[inline]
 pub fn find_ephemeral_base_crank_pda_unscoped(seed: &[u8; 32]) -> (solana_address::Address, u8) {
-    solana_address::Address::find_program_address(
-        &[crate::consts::CRANK_SEED_PREFIX, seed.as_ref()],
-        &crate::ephemeral::ID,
-    )
+    find_crank_pda_unscoped_with_program_id(seed, &crate::ephemeral::ID)
 }

--- a/programs/hydra/Cargo.toml
+++ b/programs/hydra/Cargo.toml
@@ -32,7 +32,7 @@ pinocchio = { workspace = true, features = ["unsafe-account-resize"] }
 pinocchio-system = { workspace = true }
 pinocchio-log = { workspace = true }
 solana-define-syscall = { workspace = true }
-hydra-api = { workspace = true }
+hydra-api = { workspace = true, features = ["program"] }
 
 [package.metadata.solana]
 program-id = "Hydra17i1feui9deaxu6d1TzSQMRNHeBRkDR1Awy7zea"

--- a/programs/hydra/src/lib.rs
+++ b/programs/hydra/src/lib.rs
@@ -3,7 +3,6 @@
 #[cfg(not(feature = "no-entrypoint"))]
 mod entrypoint;
 
-mod helpers;
 mod processor;
 
-pub use hydra_api::base::ID;
+pub use hydra_api::base::*;

--- a/programs/hydra/src/processor/cancel.rs
+++ b/programs/hydra/src/processor/cancel.rs
@@ -2,49 +2,12 @@
 
 use pinocchio::{error::ProgramError, AccountView, ProgramResult};
 
-use hydra_api::{state::load_crank, HydraError};
+use hydra_api::program::processor::process_cancel;
 
 pub fn process(accounts: &mut [AccountView], _data: &[u8]) -> ProgramResult {
     let [authority, crank_ai, recipient] = accounts else {
         return Err(ProgramError::NotEnoughAccountKeys);
     };
 
-    if !authority.is_signer() {
-        return Err(ProgramError::MissingRequiredSignature);
-    }
-    if !crank_ai.owned_by(&hydra_api::base::ID) {
-        return Err(ProgramError::InvalidAccountOwner);
-    }
-
-    // Read the stored authority and bail if unkillable (all-zeros) or
-    // doesn't match the signer.
-    let stored_authority = {
-        let data = crank_ai.try_borrow()?;
-        let state = unsafe { load_crank(&data)? };
-        state.authority
-    };
-
-    if stored_authority == [0u8; 32] {
-        return Err(HydraError::UnauthorizedAuthority.into());
-    }
-    if authority.address().as_array() != &stored_authority {
-        return Err(HydraError::UnauthorizedAuthority.into());
-    }
-
-    drain_lamports(crank_ai, recipient)
-}
-
-/// Move all lamports out of `src` into `dst`. The runtime zeroes `src.data`
-/// and reassigns ownership to the system program at the instruction boundary
-/// because `src.lamports == 0` post-write.
-#[inline(always)]
-pub(super) fn drain_lamports(src: &mut AccountView, dst: &mut AccountView) -> ProgramResult {
-    let amount = src.lamports();
-    let new_dst = dst
-        .lamports()
-        .checked_add(amount)
-        .ok_or(ProgramError::ArithmeticOverflow)?;
-    src.set_lamports(0);
-    dst.set_lamports(new_dst);
-    Ok(())
+    process_cancel(authority, crank_ai, recipient, &crate::ID)
 }

--- a/programs/hydra/src/processor/close.rs
+++ b/programs/hydra/src/processor/close.rs
@@ -3,89 +3,18 @@
 //! than `STALENESS_THRESHOLD_SLOTS` behind the current slot, which means no
 //! cranker has successfully fired it in ~10 days — almost always because the
 //! inner ix deterministically fails.
+//!
+//! The closable check + bounty/refund payout is shared with the ephemeral
+//! program via [`hydra_api::program::processor::process_close`].
 
 use pinocchio::{error::ProgramError, AccountView, ProgramResult};
 
-use hydra_api::{
-    consts::base::{CRANKER_REWARD, STALENESS_THRESHOLD_SLOTS},
-    state::load_crank,
-    HydraError,
-};
-
-use crate::helpers::get_clock_slot;
+use hydra_api::program::processor::process_close;
 
 pub fn process(accounts: &mut [AccountView], _data: &[u8]) -> ProgramResult {
     let [reporter, crank_ai, recipient] = accounts else {
         return Err(ProgramError::NotEnoughAccountKeys);
     };
 
-    if !reporter.is_signer() {
-        return Err(ProgramError::MissingRequiredSignature);
-    }
-    if !crank_ai.owned_by(&hydra_api::base::ID) {
-        return Err(ProgramError::InvalidAccountOwner);
-    }
-
-    // Snapshot fields we need from the crank header.
-    let (stored_authority, remaining, rent_min, priority_tip, next_exec_slot, lamports_now) = {
-        let data = crank_ai.try_borrow()?;
-        let state = unsafe { load_crank(&data)? };
-        (
-            state.authority,
-            state.remaining(),
-            state.rent_min(),
-            state.priority_tip(),
-            state.next_exec_slot(),
-            crank_ai.lamports(),
-        )
-    };
-
-    // Pre-condition: exhausted OR underfunded OR stuck.
-    let exhausted = remaining == 0;
-    let next_reward = CRANKER_REWARD
-        .checked_add(priority_tip)
-        .ok_or(ProgramError::ArithmeticOverflow)?;
-    let underfunded = lamports_now
-        < rent_min
-            .checked_add(next_reward)
-            .ok_or(ProgramError::ArithmeticOverflow)?;
-    // `next_exec_slot` only advances on *successful* `Trigger`, so persistent
-    // failure pins it in the past. `saturating_sub` makes future-scheduled
-    // cranks (`next_exec_slot > current_slot`) trivially not-stale.
-    let current_slot = get_clock_slot()?;
-    let stuck = current_slot.saturating_sub(next_exec_slot) > STALENESS_THRESHOLD_SLOTS;
-
-    if !(exhausted || underfunded || stuck) {
-        return Err(HydraError::NotClosable.into());
-    }
-
-    // Anti-grief: if an authority is set, only they can receive the refund.
-    // Anyone can still invoke Close, but they can't redirect the rent refund.
-    if stored_authority != [0u8; 32] && recipient.address().as_array() != &stored_authority {
-        return Err(HydraError::UnauthorizedAuthority.into());
-    }
-
-    // Flat bounty (2 × base fee) to whoever cranked the cleanup; the balance
-    // refunds to `recipient`. `min` handles a crank holding less than the
-    // bounty — reporter gets what's there, recipient gets nothing.
-    let bounty = CRANKER_REWARD.min(lamports_now);
-    let refund = lamports_now - bounty;
-
-    crank_ai.set_lamports(0);
-
-    let new_reporter = reporter
-        .lamports()
-        .checked_add(bounty)
-        .ok_or(ProgramError::ArithmeticOverflow)?;
-    reporter.set_lamports(new_reporter);
-
-    // When `recipient` aliases `reporter`, the write above is visible here, so
-    // adding `refund` on top preserves the sum. Distinct accounts: clean credit.
-    let new_recipient = recipient
-        .lamports()
-        .checked_add(refund)
-        .ok_or(ProgramError::ArithmeticOverflow)?;
-    recipient.set_lamports(new_recipient);
-
-    Ok(())
+    process_close(reporter, crank_ai, recipient, &crate::ID, false)
 }

--- a/programs/hydra/src/processor/common.rs
+++ b/programs/hydra/src/processor/common.rs
@@ -1,0 +1,14 @@
+//! Raw-pointer field helpers for the base-layer `Trigger` hot path. The lamport
+//! drain + close/cancel payout logic is shared with the ephemeral program via
+//! [`hydra_api::program::processor`].
+
+/// Read/write the 8-byte header fields the `Trigger` hot path touches directly.
+#[inline(always)]
+pub(super) unsafe fn read_u64(p: *const u8) -> u64 {
+    core::ptr::read_unaligned(p as *const u64)
+}
+
+#[inline(always)]
+pub(super) unsafe fn write_u64(p: *mut u8, v: u64) {
+    core::ptr::write_unaligned(p as *mut u64, v);
+}

--- a/programs/hydra/src/processor/create.rs
+++ b/programs/hydra/src/processor/create.rs
@@ -22,7 +22,7 @@ use pinocchio::{
     cpi::{Seed, Signer},
     error::ProgramError,
     sysvars::{rent::Rent, Sysvar},
-    AccountView, Address, ProgramResult, UnsafeResize,
+    AccountView, ProgramResult,
 };
 #[cfg(not(feature = "create-account-allow-prefund"))]
 use pinocchio_system::instructions::{Allocate, Assign, CreateAccount, Transfer};
@@ -30,13 +30,8 @@ use pinocchio_system::instructions::{Allocate, Assign, CreateAccount, Transfer};
 use pinocchio_system::instructions::{CreateAccountAllowPrefund, Funding};
 
 use hydra_api::{
-    consts::{
-        ix as _ix, CRANK_HEADER_SIZE, CRANK_SEED_PREFIX, MAX_ACCOUNTS, MAX_COMPUTE_UNIT_LIMIT,
-        MAX_DATA_LEN, MAX_INSTRUCTIONS, META_FLAG_SIGNER, REMAINING_INFINITE, SERIALIZED_META_SIZE,
-    },
-    instruction::{CREATE_FIXED_PREFIX_LEN, CREATE_IX_HEADER_LEN},
-    state::load_crank_mut,
-    HydraError,
+    consts::{CRANK_HEADER_SIZE, CRANK_SEED_PREFIX},
+    program::processor::{derive_crank_pda, measure_region, parse_create_header, write_crank},
 };
 
 pub fn process(accounts: &mut [AccountView], data: &[u8]) -> ProgramResult {
@@ -44,69 +39,19 @@ pub fn process(accounts: &mut [AccountView], data: &[u8]) -> ProgramResult {
         return Err(ProgramError::NotEnoughAccountKeys);
     };
 
-    // Need at least the scheduling prefix plus one ix blob header.
-    if data.len() < CREATE_FIXED_PREFIX_LEN + CREATE_IX_HEADER_LEN {
-        return Err(ProgramError::InvalidInstructionData);
-    }
+    let header = parse_create_header(data)?;
+    let authority_signer: u8 = (payer.address().as_array() == &header.authority) as u8;
 
-    // SAFETY: bounds checked above; Address/u64/u16 only require byte alignment.
-    let seed: &[u8; 32] = unsafe { &*(data.as_ptr() as *const [u8; 32]) };
-    let authority: &[u8; 32] = unsafe { &*(data.as_ptr().add(32) as *const [u8; 32]) };
-    let start_slot = read_u64_le(data, 64);
-    let interval_slots = read_u64_le(data, 72);
-    let remaining_wire = read_u64_le(data, 80);
-    let priority_tip = read_u64_le(data, 88);
-    let cu_limit = read_u32_le(data, 96);
-
-    // `0` is the documented opt-out. Any non-zero value must be within the
-    // Solana per-tx ceiling or the runtime would reject the cranker's tx.
-    if cu_limit > MAX_COMPUTE_UNIT_LIMIT {
-        return Err(HydraError::InvalidSchedule.into());
-    }
-    // A never-advancing infinite crank makes no sense.
-    if remaining_wire == 0 && interval_slots == 0 {
-        return Err(HydraError::InvalidSchedule.into());
-    }
-
-    let authority_signer: u8 = (payer.address().as_array() == authority) as u8;
-
-    // Re-serializing each scheduled ix into the instructions-sysvar tail layout
-    // widens its `num_accounts` from u8 to u16 — exactly one extra byte per ix —
-    // so the tail length is `body_len + num_instructions`, which is at most
-    // `body_len + MAX_INSTRUCTIONS`. Create the account at that O(1) upper bound,
-    // then validate + serialize the tail in a single pass and shrink to the
-    // exact length. This avoids a separate pass just to pre-compute the size.
-    let body_len = data.len() - CREATE_FIXED_PREFIX_LEN;
-    let upper_region = body_len + MAX_INSTRUCTIONS;
-    // The exact tail length (`<= upper_region`) is stored in a `u16` header field.
-    if upper_region > u16::MAX as usize {
-        return Err(HydraError::InvalidSchedule.into());
-    }
-
-    // Derive the payer-bound PDA (`[b"crank", payer, seed]`) — squat-proof:
-    // a different payer derives a different address.
-    let payer_key = payer.address();
-    let (expected_pda, bump) = Address::find_program_address(
-        &[CRANK_SEED_PREFIX, payer_key.as_ref(), seed.as_ref()],
-        &hydra_api::base::ID,
-    );
-    let payer_bound = crank_ai.address() == &expected_pda;
-    // DEPRECATED: legacy unscoped derivation (`[b"crank", seed]`) is squattable.
-    // TODO: remove this fallback once all integrators are on payer-bound PDAs.
-    let bump = if payer_bound {
-        bump
-    } else {
-        let (legacy_pda, legacy_bump) = Address::find_program_address(
-            &[CRANK_SEED_PREFIX, seed.as_ref()],
-            &hydra_api::base::ID,
-        );
-        if crank_ai.address() != &legacy_pda {
-            return Err(ProgramError::InvalidSeeds);
-        }
-        legacy_bump
-    };
-
-    let total_size = CRANK_HEADER_SIZE + upper_region;
+    // Size the account from the scheduled ixs (validates the schedule), verify
+    // the PDA, then allocate at exactly that size. The tail is written below.
+    let region_len = measure_region(data)?;
+    let (bump, payer_bound) = derive_crank_pda(
+        crank_ai,
+        payer.address().as_array(),
+        &header.seed,
+        &crate::ID,
+    )?;
+    let total_size = CRANK_HEADER_SIZE + region_len;
 
     // One sysvar read serves both CreateAccount funding and the cached floor.
     let rent = Rent::get()?;
@@ -116,13 +61,13 @@ pub fn process(accounts: &mut [AccountView], data: &[u8]) -> ProgramResult {
     let bump_arr = [bump];
     let payer_seeds = [
         Seed::from(CRANK_SEED_PREFIX),
-        Seed::from(payer_key.as_ref()),
-        Seed::from(seed.as_ref()),
+        Seed::from(payer.address().as_array()),
+        Seed::from(header.seed.as_ref()),
         Seed::from(&bump_arr),
     ];
     let legacy_seeds = [
         Seed::from(CRANK_SEED_PREFIX),
-        Seed::from(seed.as_ref()),
+        Seed::from(header.seed.as_ref()),
         Seed::from(&bump_arr),
     ];
     let signers = [if payer_bound {
@@ -192,111 +137,14 @@ pub fn process(accounts: &mut [AccountView], data: &[u8]) -> ProgramResult {
         }
     }
 
-    // Validate each scheduled ix and re-serialize it into the tail in the
-    // instructions-sysvar wire layout, counting and accumulating the exact
-    // length as we go. The account is over-provisioned to `upper_region`, so
-    // every write stays in bounds (the tail is at most one byte per ix longer
-    // than the wire body, and there are at most `MAX_INSTRUCTIONS` of them).
-    let region_len = {
-        let mut account_data = crank_ai.try_borrow_mut()?;
-        let buf: &mut [u8] = &mut account_data;
-        let (header_bytes, tail_bytes) = buf.split_at_mut(CRANK_HEADER_SIZE);
-
-        let mut cursor = CREATE_FIXED_PREFIX_LEN;
-        let mut off = 0usize;
-        let mut num_instructions = 0usize;
-
-        while cursor < data.len() {
-            if cursor + CREATE_IX_HEADER_LEN > data.len() {
-                return Err(ProgramError::InvalidInstructionData);
-            }
-            num_instructions += 1;
-            if num_instructions > MAX_INSTRUCTIONS {
-                return Err(HydraError::InvalidSchedule.into());
-            }
-            let num_accounts = data[cursor] as usize;
-            let data_len = u16::from_le_bytes([data[cursor + 1], data[cursor + 2]]) as usize;
-            if num_accounts > MAX_ACCOUNTS || data_len > MAX_DATA_LEN {
-                return Err(HydraError::InvalidSchedule.into());
-            }
-            let metas_offset = cursor + CREATE_IX_HEADER_LEN;
-            let metas_len = num_accounts * SERIALIZED_META_SIZE;
-            let data_offset = metas_offset + metas_len;
-            let next = data_offset + data_len;
-            if next > data.len() {
-                return Err(ProgramError::InvalidInstructionData);
-            }
-            // Reject any signer flag — scheduled ixs run top-level, they can
-            // only be signed by real keys, and this program can't produce a
-            // signature for a declared pubkey anyway. Writability consistency and
-            // triggerability are the client's responsibility (see [`hydra_api::instruction::client::CreateArgs`]);
-            for account_index in 0..num_accounts {
-                if data[metas_offset + account_index * SERIALIZED_META_SIZE] & META_FLAG_SIGNER != 0
-                {
-                    return Err(HydraError::SignerInScheduledIx.into());
-                }
-            }
-            // Tail blob, instructions-sysvar layout:
-            // [num_accounts u16][metas][program_id 32][data_len u16][data]
-            tail_bytes[off..off + 2].copy_from_slice(&(num_accounts as u16).to_le_bytes());
-            off += 2;
-            tail_bytes[off..off + metas_len].copy_from_slice(&data[metas_offset..data_offset]);
-            off += metas_len;
-            tail_bytes[off..off + 32]
-                .copy_from_slice(&data[cursor + 3..cursor + CREATE_IX_HEADER_LEN]);
-            off += 32;
-            tail_bytes[off..off + 2].copy_from_slice(&(data_len as u16).to_le_bytes());
-            off += 2;
-            tail_bytes[off..off + data_len].copy_from_slice(&data[data_offset..next]);
-            off += data_len;
-
-            cursor = next;
-        }
-
-        // SAFETY: split yields CRANK_HEADER_SIZE bytes; Crank is align-1 (compile-time checked).
-        let state = unsafe { load_crank_mut(header_bytes)? };
-        state.authority = *authority;
-        state.seed = *seed;
-        state.set_next_exec_slot(start_slot);
-        state.set_interval_slots(interval_slots);
-        state.set_remaining(if remaining_wire == 0 {
-            REMAINING_INFINITE
-        } else {
-            remaining_wire
-        });
-        state.set_priority_tip(priority_tip);
-        state.set_executed(0);
-        state.set_rent_min(rent_min);
-        state.set_region_len(off as u16);
-        state.bump = bump;
-        state.set_cu_limit(cu_limit);
-        state.authority_signer = authority_signer;
-
-        off
-    };
-
-    // Trim the over-provisioned account down to its exact size. Shrinking only
-    // lowers the data-length field — no syscall, never out of bounds — so the
-    // unchecked variant is safe: `region_len <= upper_region`, the borrow above
-    // is dropped, and the crank is program-owned after `CreateAccount`.
-    unsafe {
-        crank_ai.resize(CRANK_HEADER_SIZE + region_len);
-    }
-
-    // Suppress unused-import warnings when `logging` feature is off.
-    let _ = _ix::CREATE;
-
-    Ok(())
-}
-
-#[inline(always)]
-fn read_u64_le(data: &[u8], offset: usize) -> u64 {
-    // SAFETY: the caller ensures `offset + 8 <= data.len()`.
-    unsafe { u64::from_le_bytes(*(data.as_ptr().add(offset) as *const [u8; 8])) }
-}
-
-#[inline(always)]
-fn read_u32_le(data: &[u8], offset: usize) -> u32 {
-    // SAFETY: the caller ensures `offset + 4 <= data.len()`.
-    unsafe { u32::from_le_bytes(*(data.as_ptr().add(offset) as *const [u8; 4])) }
+    // The account is sized to `region_len`, so `write_crank` fills it exactly.
+    write_crank(
+        crank_ai,
+        data,
+        &header,
+        bump,
+        authority_signer,
+        rent_min,
+        region_len,
+    )
 }

--- a/programs/hydra/src/processor/mod.rs
+++ b/programs/hydra/src/processor/mod.rs
@@ -1,4 +1,12 @@
+//! Base-layer crank lifecycle.
+//!
+//! Schedule parsing, tail serialization and follow-up verification are shared
+//! with the ephemeral-rollup program via [`hydra_api::program`]; only the
+//! System-program funding model lives here.
+
 pub mod cancel;
 pub mod close;
 pub mod create;
 pub mod trigger;
+
+mod common;

--- a/programs/hydra/src/processor/trigger.rs
+++ b/programs/hydra/src/processor/trigger.rs
@@ -11,11 +11,16 @@ use pinocchio::{
 };
 
 use hydra_api::{
-    consts::{base::CRANKER_REWARD, CRANK_HEADER_SIZE, REMAINING_INFINITE},
+    consts::{base, CRANK_HEADER_SIZE, REMAINING_INFINITE},
     HydraError,
 };
 
-use crate::helpers::{get_clock_slot, get_stack_height, TRANSACTION_LEVEL_STACK_HEIGHT};
+use hydra_api::program::{
+    helpers::{get_clock_slot, get_stack_height, TRANSACTION_LEVEL_STACK_HEIGHT},
+    processor::{read_u16, verify_followup},
+};
+
+use crate::processor::common::{read_u64, write_u64};
 
 // Field offsets inside the 120-byte `Crank` header, kept local to this file
 // so the raw reads below stay easy to verify against the account layout.
@@ -37,7 +42,7 @@ pub fn process(accounts: &mut [AccountView], _data: &[u8]) -> ProgramResult {
     if !cranker_ai.is_signer() {
         return Err(ProgramError::MissingRequiredSignature);
     }
-    if !crank_ai.owned_by(&hydra_api::base::ID) {
+    if !crank_ai.owned_by(&crate::ID) {
         return Err(ProgramError::InvalidAccountOwner);
     }
     if ix_sysvar_ai.address() != &INSTRUCTIONS_ID {
@@ -72,7 +77,7 @@ pub fn process(accounts: &mut [AccountView], _data: &[u8]) -> ProgramResult {
         return Err(HydraError::Exhausted.into());
     }
 
-    let reward = CRANKER_REWARD
+    let reward = base::CRANKER_REWARD
         .checked_add(hdr.priority_tip)
         .ok_or(ProgramError::ArithmeticOverflow)?;
     let new_crank_lamports = crank_ai
@@ -155,74 +160,4 @@ unsafe fn read_header(p: *const u8) -> Snapshot {
         rent_min: read_u64(p.add(OFF_RENT_MIN)),
         region_len: read_u16(p.add(OFF_REGION_LEN)),
     }
-}
-
-/// Parse the instructions sysvar, locate the region for
-/// `current_ix_index + 1`, and byte-compare it against the crank's stored tail.
-#[inline(always)]
-fn verify_followup(sysvar: &AccountView, crank: &AccountView, region_len: usize) -> ProgramResult {
-    // SAFETY: we're in a linear entrypoint flow with no outstanding borrows
-    // on either account. pinocchio's `borrow_unchecked` skips the refcell
-    // bookkeeping, which saves a handful of CUs per call.
-    let sv: &[u8] = unsafe { sysvar.borrow_unchecked() };
-    let cr: &[u8] = unsafe { crank.borrow_unchecked() };
-
-    let sv_len = sv.len();
-    if sv_len < 4 {
-        return Err(ProgramError::InvalidAccountData);
-    }
-
-    // [len-2..len] = current_ix_index (u16 LE)
-    let current = unsafe { read_u16(sv.as_ptr().add(sv_len - 2)) } as usize;
-    let target = current
-        .checked_add(1)
-        .ok_or(HydraError::MissingFollowupInstruction)?;
-
-    // [0..2] = num_instructions (u16 LE)
-    let num_ix = unsafe { read_u16(sv.as_ptr()) } as usize;
-    if target >= num_ix {
-        return Err(HydraError::MissingFollowupInstruction.into());
-    }
-
-    // [2 + 2*target..+2] = offset of instruction `target`'s region.
-    let off_pos = 2 + 2 * target;
-    if off_pos + 2 > sv_len {
-        return Err(ProgramError::InvalidAccountData);
-    }
-    let region_start = unsafe { read_u16(sv.as_ptr().add(off_pos)) } as usize;
-    let region_end = region_start
-        .checked_add(region_len)
-        .ok_or(HydraError::MismatchedFollowupIx)?;
-    if region_end > sv_len.saturating_sub(2) {
-        return Err(HydraError::MismatchedFollowupIx.into());
-    }
-
-    let tail_end = CRANK_HEADER_SIZE
-        .checked_add(region_len)
-        .ok_or(ProgramError::InvalidAccountData)?;
-    if tail_end > cr.len() {
-        return Err(ProgramError::InvalidAccountData);
-    }
-    let tail = &cr[CRANK_HEADER_SIZE..tail_end];
-    let sv_region = &sv[region_start..region_end];
-
-    if sv_region != tail {
-        return Err(HydraError::MismatchedFollowupIx.into());
-    }
-    Ok(())
-}
-
-#[inline(always)]
-unsafe fn read_u64(p: *const u8) -> u64 {
-    core::ptr::read_unaligned(p as *const u64)
-}
-
-#[inline(always)]
-unsafe fn read_u16(p: *const u8) -> u16 {
-    core::ptr::read_unaligned(p as *const u16)
-}
-
-#[inline(always)]
-unsafe fn write_u64(p: *mut u8, v: u64) {
-    core::ptr::write_unaligned(p as *mut u64, v);
 }


### PR DESCRIPTION
Closes #24

Schedule parsing, tail serialization, follow-up verification and the
sysvar syscalls move behind a new `program` feature so the upcoming
ephemeral program can reuse them. programs/hydra keeps only the
System-program funding model, delegating to process_{create,trigger,
cancel,close}.

Behaviour-preserving: tests/lib.rs is untouched and all 26 tests pass.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>