### PR TITLE
feat: add the hydra-ephemeral program

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "2"
 default-members = ["programs/hydra"]
 members = [
     "programs/hydra",
+    "programs/hydra-ephemeral",
     "crates/hydra-api",
     "crates/hydra-cranker",
     "tests",

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ SHELL := /bin/bash
 
 # Manifests for the crates that live outside the default workspace build.
 BASE_MANIFEST     := programs/hydra/Cargo.toml
+EPHEMERAL_MANIFEST := programs/hydra-ephemeral/Cargo.toml
 NOOP_MANIFEST      := tests/programs/noop/Cargo.toml
 NATIVE_MANIFEST    := examples/native/Cargo.toml
 PINOCCHIO_MANIFEST := examples/pinocchio/Cargo.toml
@@ -42,6 +43,7 @@ help: ## Show this help
 build: ## build-sbf the noop + hydra programs
 	cargo build-sbf --manifest-path $(NOOP_MANIFEST)
 	cargo build-sbf --manifest-path $(BASE_MANIFEST)
+	cargo build-sbf --manifest-path $(EPHEMERAL_MANIFEST)
 
 build-examples: ## build-sbf the native + pinocchio example programs
 	cargo build-sbf --manifest-path $(NATIVE_MANIFEST)
@@ -56,7 +58,7 @@ build-anchor: ## anchor build the anchor example (needs the anchor CLI)
 # ---------------------------------------------------------------------------
 # Format & lint (mirrors the fmt + default CI jobs).
 # ---------------------------------------------------------------------------
-.PHONY: fmt fmt-check lint
+.PHONY: fmt fmt-check lint lint-ephemeral
 
 fmt: ## Format the workspace and the excluded anchor example
 	cargo fmt --all

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ PINOCCHIO_MANIFEST := examples/pinocchio/Cargo.toml
 ANCHOR_MANIFEST    := examples/anchor/Cargo.toml
 
 HYDRA_FEATURES := logging,cu-trace
+EPHEMERAL_FEATURES := logging
 
 CLIPPY := --all-targets -- -D warnings
 
@@ -58,7 +59,7 @@ build-anchor: ## anchor build the anchor example (needs the anchor CLI)
 # ---------------------------------------------------------------------------
 # Format & lint (mirrors the fmt + default CI jobs).
 # ---------------------------------------------------------------------------
-.PHONY: fmt fmt-check lint lint-ephemeral
+.PHONY: fmt fmt-check lint
 
 fmt: ## Format the workspace and the excluded anchor example
 	cargo fmt --all
@@ -68,9 +69,10 @@ fmt-check: ## Check formatting without writing (CI)
 	cargo fmt --all --check
 	cargo fmt --manifest-path $(ANCHOR_MANIFEST) --all --check
 
-lint: ## Clippy the workspace, hydra's optional features, and the anchor example
+lint: ## Clippy the workspace, both programs' optional features, and the anchor example
 	cargo clippy --workspace $(CLIPPY)
 	cargo clippy -p hydra --features $(HYDRA_FEATURES) $(CLIPPY)
+	cargo clippy -p hydra-ephemeral --features $(EPHEMERAL_FEATURES) $(CLIPPY)
 	cargo clippy --manifest-path $(ANCHOR_MANIFEST) $(CLIPPY)
 
 # ---------------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -81,22 +81,39 @@ payload size (it is a one-time cost dominated by the account-creation syscall).
 Reproduce:
 
 ```sh
-cargo build-sbf --manifest-path programs/hydra/Cargo.toml
-cargo build-sbf --manifest-path tests/programs/noop/Cargo.toml
-cargo test -p hydra-tests cu_table -- --ignored --nocapture
+make cu-table
 ```
 
 ## Build
 
+Run `make help` to list the available targets. Common commands:
+
+- `make build` — build the base and ephemeral on-chain programs.
+- `make fmt` / `make fmt-check` — format Rust sources or check formatting.
+- `make lint` — run clippy for the workspace, plus the Anchor example check.
+- `make test` — run the main `hydra-tests` suite.
+- `make test-examples` — run the native and Pinocchio example tests.
+- `make test-e2e` — run the live ephemeral-rollup e2e test.
+- `make cu-table` — reproduce the compute-unit table.
+- `make ci` — run the default CI checks locally.
+- `make install-tools` — install `cargo-nextest`.
+- `make clean` — remove Cargo build artifacts.
+
 ```sh
-# Build the on-chain program.
-cargo build-sbf --manifest-path programs/hydra/Cargo.toml
+# Show available build, lint, and test targets.
+make help
+
+# Build the on-chain programs.
+make build
 
 # Build the cranker.
 cargo build -p hydra-cranker
 
-# Run the test suite.
-cargo test -p hydra-tests
+# Run the main test suite.
+make test
+
+# Run the default CI checks locally.
+make ci
 ```
 
 ## Integrating Hydra
@@ -121,7 +138,7 @@ Examples:
 ## Creating a Crank
 
 ```rust
-use hydra_api::instruction::{self as ix, CreateArgs, ScheduledIx};
+use hydra_api::instruction::{base as ix, CreateArgs, ScheduledIx};
 
 let seed = [0x42u8; 32];
 let (crank, _bump) = ix::find_crank_pda(&payer_pubkey, &seed);
@@ -232,6 +249,14 @@ hydra-cranker \
   --rpc-url https://your.rpc.example \
   --ws-url wss://your.rpc.example
 
+# Against a MagicBlock ephemeral rollup. `--ephemeral` switches the target
+# program, the `Close` account layout, and the (zero-lamport) funding model at
+# runtime — the same binary drives either program, no rebuild needed.
+hydra-cranker \
+  --keypair ~/.config/solana/cranker.json \
+  --rpc-url https://your.rollup.example \
+  --ephemeral
+
 # With Prometheus metrics at http://0.0.0.0:9100/metrics
 # and JSON health at http://0.0.0.0:9100/healthz
 hydra-cranker \
@@ -259,21 +284,21 @@ parked after repeated failures. It returns `503` before the first slot, when the
 last slot sweep is older than 30 seconds, when eligible cranks are parked, or
 when triggerable cranks were not attempted on the latest sweep.
 
-| Metric | Type | Labels | Meaning |
-|---|---|---|---|
-| `cranks_cached` | gauge | — | Cranks currently in the in-memory cache. |
-| `current_slot` | gauge | — | Last slot observed from `slotSubscribe`. |
-| `eligible_now` | gauge | — | Cranks eligible to trigger on the last slot tick. |
-| `triggerable_now` | gauge | — | Eligible cranks after local cooldown/backoff filtering. |
-| `parked_now` | gauge | — | Eligible cranks parked after repeated failures at the same `next_exec_slot`. |
-| `max_overdue_slots` | gauge | — | Largest `current_slot - next_exec_slot` among currently eligible cranks. |
-| `triggers_submitted_total` | counter | `result={ok,err}` | Triggers submitted. |
-| `closes_submitted_total` | counter | `result={ok,err}` | Permissionless `Close` transactions submitted. |
-| `ws_reconnects_total` | counter | `source={program,slot}` | WS (re)connect attempts. |
-| `grpc_reconnects_total` | counter | `source={program,slot}` | Yellowstone gRPC (re)connect attempts (only when `--grpc-url` is set). |
-| `cache_events_total` | counter | `kind={insert,update,remove}` | Cache mutations driven by `programSubscribe`. |
-| `sweep_duration_seconds` | histogram | — | Wall time per slot-tick sweep (scan + fire). Buckets target sub-10 ms. |
-| `rpc_errors_total` | counter | `op={get_program_accounts,get_latest_blockhash,send_transaction}` | RPC call errors, by failing operation. |
+| Metric                     | Type      | Labels                                                            | Meaning                                                                      |
+| -------------------------- | --------- | ----------------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| `cranks_cached`            | gauge     | —                                                                 | Cranks currently in the in-memory cache.                                     |
+| `current_slot`             | gauge     | —                                                                 | Last slot observed from `slotSubscribe`.                                     |
+| `eligible_now`             | gauge     | —                                                                 | Cranks eligible to trigger on the last slot tick.                            |
+| `triggerable_now`          | gauge     | —                                                                 | Eligible cranks after local cooldown/backoff filtering.                      |
+| `parked_now`               | gauge     | —                                                                 | Eligible cranks parked after repeated failures at the same `next_exec_slot`. |
+| `max_overdue_slots`        | gauge     | —                                                                 | Largest `current_slot - next_exec_slot` among currently eligible cranks.     |
+| `triggers_submitted_total` | counter   | `result={ok,err}`                                                 | Triggers submitted.                                                          |
+| `closes_submitted_total`   | counter   | `result={ok,err}`                                                 | Permissionless `Close` transactions submitted.                               |
+| `ws_reconnects_total`      | counter   | `source={program,slot}`                                           | WS (re)connect attempts.                                                     |
+| `grpc_reconnects_total`    | counter   | `source={program,slot}`                                           | Yellowstone gRPC (re)connect attempts (only when `--grpc-url` is set).       |
+| `cache_events_total`       | counter   | `kind={insert,update,remove}`                                     | Cache mutations driven by `programSubscribe`.                                |
+| `sweep_duration_seconds`   | histogram | —                                                                 | Wall time per slot-tick sweep (scan + fire). Buckets target sub-10 ms.       |
+| `rpc_errors_total`         | counter   | `op={get_program_accounts,get_latest_blockhash,send_transaction}` | RPC call errors, by failing operation.                                       |
 
 Useful alerts:
 
@@ -286,6 +311,20 @@ Useful alerts:
 - `rate(hydra_cranker_rpc_errors_total[5m]) > 0.1` — RPC endpoint failing a notable fraction of calls.
 
 ## Instruction Reference
+
+Hydra ships as **two on-chain programs** that share the same discriminators
+(`0–3`) and on-chain `Crank` layout, distinguished by program ID:
+
+- `hydra` (`Hydra17…`) — the base-layer crank, in `programs/hydra`.
+- `hydra-ephemeral` (`eHyd5…`) — the
+  [ephemeral-rollup crank](#ephemeral-rollup-crank-hydra-ephemeral-program), in
+  `programs/hydra-ephemeral`.
+
+The instruction-parsing, tail-serialization and follow-up-verification logic is
+shared between them via [`hydra_api::program`] (behind the api crate's `program`
+feature); each program only carries its own account-funding model.
+
+The base-layer (`hydra`) instructions:
 
 | Disc | Name      | Accounts                                      | Data             |
 | ---: | --------- | --------------------------------------------- | ---------------- |
@@ -305,10 +344,105 @@ the crank PDA — no dedicated instruction exists.
 - `MAX_DATA_LEN = 1024`
 - reward is fixed at `10_000` lamports plus the stored priority tip
 
+## Ephemeral Rollup Crank (`hydra-ephemeral` program)
+
+The separate `hydra-ephemeral` program (ID `eHyd5…`, crate
+`programs/hydra-ephemeral`) runs a crank on a
+[MagicBlock](https://magicblock.gg) **ephemeral rollup (ER)**, where the crank
+lives as a MagicBlock **ephemeral account** instead of a base-layer PDA. The
+base-layer `hydra` program neither contains this code nor depends on
+`ephemeral-rollups-pinocchio`; the two programs share their schedule/verify
+logic through [`hydra_api::program`].
+
+The economic model is identical to the base crank — the cranker is paid
+`CRANKER_REWARD + priority_tip` out of the crank's lamport balance on `Trigger`,
+and `Cancel`/`Close` pay out the leftover balance — with two differences the ER
+forces:
+
+- **Vault rent is separate from the crank balance.** The ephemeral account's rent
+  (a flat per-byte fee) is paid by a sponsor into a shared vault, not held in the
+  account, so the crank's stored `rent_min` is `0`. The crank still holds a plain
+  lamport balance (funded by the sponsor) that funds the cranker rewards, exactly
+  like base; the only `Trigger` floor is being able to afford the reward.
+- **Creation/teardown go through the Magic program.** The Magic program
+  materializes the ephemeral account synchronously, so `Create` allocates the
+  crank (via a Magic CPI signed by the crank PDA) and writes its header +
+  scheduled-ix tail in one instruction. `Cancel`/`Close` first drain the crank's
+  leftover lamports to a `recipient` (the same bounty/refund split as base), then
+  CPI Magic `close` to deallocate the account and refund the vault rent to the
+  sponsor.
+
+Lifecycle: `Create` → `Trigger` (+ scheduled siblings, run top-level on the ER) →
+`Cancel` (authority-gated) / `Close` (exhausted, underfunded, or stuck). On
+teardown the leftover balance refunds to `recipient` and the vault rent refunds
+to whoever signs the teardown. Because the Magic program refunds the vault rent
+to the teardown's signer, `Close` is only *permissionless for unowned cranks*
+(`authority == 0`): when a non-zero `authority` is set, only that authority may
+`Close` the crank (and only that authority may be the `recipient`), so the whole
+teardown — bounty, leftover balance, and vault rent — stays with the owner rather
+than an arbitrary reporter. Unowned cranks stay permissionlessly closable by
+anyone. The crank PDA derivation (`[b"crank", seed]`) and the on-chain `Crank`
+layout are unchanged, so the template / verification model is identical.
+
+### Instruction Reference (ephemeral)
+
+Same discriminators as the base program (`0–3`); the account shapes differ
+because creation/close go through the Magic program rather than the System
+program.
+
+| Disc | Name      | Accounts                                                          | Data             |
+| ---: | --------- | ----------------------------------------------------------------- | ---------------- |
+|    0 | `Create`  | `sponsor(w,s), crank(w), vault(w), magic_program`                 | schedule payload |
+|    1 | `Trigger` | `crank(w), cranker(w,s), instructions_sysvar`                     | none             |
+|    2 | `Cancel`  | `authority(w,s), crank(w), recipient(w), vault(w), magic_program` | none             |
+|    3 | `Close`   | `reporter(w,s), crank(w), recipient(w), vault(w), magic_program`  | none             |
+
+`vault` is the ephemeral rent vault and `magic_program` is MagicBlock's Magic
+program; `hydra-api` exposes both as `consts::magic::EPHEMERAL_VAULT_ID` /
+`MAGIC_PROGRAM_ID`, and the `client`-feature builder fills them in. `sponsor` must
+be an account delegated to the ER (it pays the rent and sets `authority_signer`).
+
+Build an ephemeral `Create` with the same `CreateArgs` as base `create`:
+
+```rust
+use hydra_api::instruction::{ephemeral as ix, CreateArgs, ScheduledIx};
+
+let (crank, _bump) = ix::find_crank_pda(&seed);
+let create = ix::create(
+    sponsor_pubkey,
+    crank,
+    &CreateArgs { seed, authority, start_slot: 0, interval_slots: 50,
+                  remaining: 0, priority_tip: 0, cu_limit: 0, scheduled },
+);
+```
+
+### Build & test
+
+#### Live end-to-end test (`tests/e2e`)
+
+`tests/e2e` instead boots the **real** three-process stack — `mb-test-validator` (base L1),
+`ephemeral-validator` (the rollup), and `hydra-cranker` — creates a few ephemeral cranks, and
+asserts the cranker fires each one on schedule.
+
+The validators ship as an npm package; `mb-test-validator` wraps
+`solana-test-validator`, so the Solana/Anza toolchain must also be installed:
+
+```sh
+npm install -g @magicblock-labs/ephemeral-validator   # mb-test-validator + ephemeral-validator
+
+# The test is `#[ignore]` (it spawns external validators); run it explicitly.
+# `make test-e2e` builds the on-chain artifacts the rollup clones first. The
+# hydra-cranker is built automatically by the test and run with `--ephemeral`.
+make test-e2e
+```
+
+CI runs this as the `e2e` job in `.github/workflows/ci.yml`.
+
 ## Releasing
 
-`hydra-api` is the only crate published to crates.io (`hydra` is a program,
-not a library; `hydra-cranker` / the examples are workspace-local).
+`hydra-api` is the only crate published to crates.io (`hydra` and
+`hydra-ephemeral` are programs, not libraries; `hydra-cranker` / the examples
+are workspace-local).
 
 Release flow:
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,6 @@ Run `make help` to list the available targets. Common commands:
 - `make lint` — run clippy for the workspace, plus the Anchor example check.
 - `make test` — run the main `hydra-tests` suite.
 - `make test-examples` — run the native and Pinocchio example tests.
-- `make test-e2e` — run the live ephemeral-rollup e2e test.
 - `make cu-table` — reproduce the compute-unit table.
 - `make ci` — run the default CI checks locally.
 - `make install-tools` — install `cargo-nextest`.
@@ -120,11 +119,16 @@ make ci
 
 Use `hydra-api` from clients or from your own on-chain program.
 
-| Use case                      | Feature         | API                            |
-| ----------------------------- | --------------- | ------------------------------ |
-| Host-side client              | `client`        | `Instruction` builders         |
-| `solana-program` / Anchor CPI | `cpi-native`    | `hydra_api::cpi::native::*`    |
-| Pinocchio CPI                 | `cpi-pinocchio` | `hydra_api::cpi::pinocchio::*` |
+| Use case                      | Feature         | API                                  |
+| ----------------------------- | --------------- | ------------------------------------ |
+| Host-side client              | `client`        | `Instruction` builders               |
+| `solana-program` / Anchor CPI | `cpi-native`    | `hydra_api::cpi::base::native::*`    |
+| Pinocchio CPI                 | `cpi-pinocchio` | `hydra_api::cpi::base::pinocchio::*` |
+
+Both the builders and the CPI helpers are split by target ledger: `base::*`
+drives the base-layer program, and `ephemeral::*` (behind the extra `ephemeral`
+feature) drives the [ephemeral-rollup
+program](#ephemeral-rollup-crank-hydra-ephemeral-program).
 
 `Trigger` is not exposed as a CPI helper. It must be sent as a top-level
 instruction.
@@ -249,14 +253,6 @@ hydra-cranker \
   --rpc-url https://your.rpc.example \
   --ws-url wss://your.rpc.example
 
-# Against a MagicBlock ephemeral rollup. `--ephemeral` switches the target
-# program, the `Close` account layout, and the (zero-lamport) funding model at
-# runtime — the same binary drives either program, no rebuild needed.
-hydra-cranker \
-  --keypair ~/.config/solana/cranker.json \
-  --rpc-url https://your.rollup.example \
-  --ephemeral
-
 # With Prometheus metrics at http://0.0.0.0:9100/metrics
 # and JSON health at http://0.0.0.0:9100/healthz
 hydra-cranker \
@@ -354,11 +350,17 @@ base-layer `hydra` program neither contains this code nor depends on
 `ephemeral-rollups-pinocchio`; the two programs share their schedule/verify
 logic through [`hydra_api::program`].
 
-The economic model is identical to the base crank — the cranker is paid
-`CRANKER_REWARD + priority_tip` out of the crank's lamport balance on `Trigger`,
-and `Cancel`/`Close` pay out the leftover balance — with two differences the ER
-forces:
+The economic model follows the same shape as the base crank — the cranker is
+paid `CRANKER_REWARD + priority_tip` out of the crank's lamport balance on
+`Trigger`, and `Cancel`/`Close` pay out the leftover balance — with three
+differences the ER forces:
 
+- **The tip is the whole reward.** ER transactions carry no base fee, so
+  `consts::ephemeral::CRANKER_REWARD` is `0` (against `10_000` on base) and the
+  crank's `priority_tip` is the cranker's *only* incentive. A crank created with
+  `priority_tip: 0` pays its cranker nothing, and the flat `Close` bounty is
+  likewise `0` — a reporter tearing down an unowned crank is paid by the vault
+  rent refund, not by the crank balance.
 - **Vault rent is separate from the crank balance.** The ephemeral account's rent
   (a flat per-byte fee) is paid by a sponsor into a shared vault, not held in the
   account, so the crank's stored `rent_min` is `0`. The crank still holds a plain
@@ -370,7 +372,7 @@ forces:
   scheduled-ix tail in one instruction. `Cancel`/`Close` first drain the crank's
   leftover lamports to a `recipient` (the same bounty/refund split as base), then
   CPI Magic `close` to deallocate the account and refund the vault rent to the
-  sponsor.
+  teardown's signer.
 
 Lifecycle: `Create` → `Trigger` (+ scheduled siblings, run top-level on the ER) →
 `Cancel` (authority-gated) / `Close` (exhausted, underfunded, or stuck). On
@@ -379,8 +381,8 @@ to whoever signs the teardown. Because the Magic program refunds the vault rent
 to the teardown's signer, `Close` is only *permissionless for unowned cranks*
 (`authority == 0`): when a non-zero `authority` is set, only that authority may
 `Close` the crank (and only that authority may be the `recipient`), so the whole
-teardown — bounty, leftover balance, and vault rent — stays with the owner rather
-than an arbitrary reporter. Unowned cranks stay permissionlessly closable by
+teardown — leftover balance and vault rent — stays with the owner rather than an
+arbitrary reporter. Unowned cranks stay permissionlessly closable by
 anyone. The crank PDA derivation (`[b"crank", seed]`) and the on-chain `Crank`
 layout are unchanged, so the template / verification model is identical.
 
@@ -398,8 +400,9 @@ program.
 |    3 | `Close`   | `reporter(w,s), crank(w), recipient(w), vault(w), magic_program`  | none             |
 
 `vault` is the ephemeral rent vault and `magic_program` is MagicBlock's Magic
-program; `hydra-api` exposes both as `consts::magic::EPHEMERAL_VAULT_ID` /
-`MAGIC_PROGRAM_ID`, and the `client`-feature builder fills them in. `sponsor` must
+program; `hydra-api` re-exports both under its `ephemeral` feature as
+`consts::magic::EPHEMERAL_VAULT_ID` / `MAGIC_PROGRAM_ID`, and the
+`client`-feature builder fills them in. `sponsor` must
 be an account delegated to the ER (it pays the rent and sets `authority_signer`).
 
 Build an ephemeral `Create` with the same `CreateArgs` as base `create`:
@@ -415,28 +418,6 @@ let create = ix::create(
                   remaining: 0, priority_tip: 0, cu_limit: 0, scheduled },
 );
 ```
-
-### Build & test
-
-#### Live end-to-end test (`tests/e2e`)
-
-`tests/e2e` instead boots the **real** three-process stack — `mb-test-validator` (base L1),
-`ephemeral-validator` (the rollup), and `hydra-cranker` — creates a few ephemeral cranks, and
-asserts the cranker fires each one on schedule.
-
-The validators ship as an npm package; `mb-test-validator` wraps
-`solana-test-validator`, so the Solana/Anza toolchain must also be installed:
-
-```sh
-npm install -g @magicblock-labs/ephemeral-validator   # mb-test-validator + ephemeral-validator
-
-# The test is `#[ignore]` (it spawns external validators); run it explicitly.
-# `make test-e2e` builds the on-chain artifacts the rollup clones first. The
-# hydra-cranker is built automatically by the test and run with `--ephemeral`.
-make test-e2e
-```
-
-CI runs this as the `e2e` job in `.github/workflows/ci.yml`.
 
 ## Releasing
 

--- a/crates/hydra-api/Cargo.toml
+++ b/crates/hydra-api/Cargo.toml
@@ -23,14 +23,16 @@ cpi-native = [
 # On-chain CPI helpers for Pinocchio callers. Wraps
 # `pinocchio::cpi::invoke_signed` with `InstructionView`s built on the
 # stack (no allocations, usable from `no_std` programs).
-cpi-pinocchio = ["pinocchio/cpi"]
+cpi-pinocchio = ["pinocchio/cpi", "dep:solana-program-error"]
 # Shared on-chain processor building blocks (schedule parsing, tail
 # serialization, follow-up verification, sysvar syscalls) consumed by the
 # `programs/hydra` and `programs/hydra-ephemeral` program crates. Pulls in
 # `solana-define-syscall` for the raw Clock / stack-height reads.
 program = ["pinocchio/cpi", "dep:solana-define-syscall"]
+ephemeral = ["dep:ephemeral-rollups-pinocchio"]
 
 [dependencies]
+ephemeral-rollups-pinocchio = { workspace = true, optional = true }
 pinocchio = { workspace = true }
 solana-address = { workspace = true }
 solana-define-syscall = { workspace = true, optional = true }

--- a/crates/hydra-api/src/cpi.rs
+++ b/crates/hydra-api/src/cpi.rs
@@ -1,7 +1,9 @@
 //! On-chain CPI wrappers for integrators who want to invoke Hydra from
 //! their own program.
 //!
-//! `native` is for `solana-program` / Anchor callers.
+//! Outer module picks the ledger: [`base`] targets the base-layer program,
+//! [`ephemeral`] (behind the `ephemeral` feature) the ephemeral-rollup one.
+//! Inside each, `native` is for `solana-program` / Anchor callers and
 //! `pinocchio` is for Pinocchio callers.
 //!
 //! `Trigger` is not exposed here. It must be sent as a top-level instruction.

--- a/crates/hydra-api/src/cpi.rs
+++ b/crates/hydra-api/src/cpi.rs
@@ -6,129 +6,373 @@
 //!
 //! `Trigger` is not exposed here. It must be sent as a top-level instruction.
 
-#[cfg(feature = "cpi-native")]
-pub mod native {
-    //! CPI wrappers for `solana-program` / Anchor callers.
-    //!
-    //! # Example
-    //!
-    //! ```ignore
-    //! use hydra_api::cpi::native as hydra_cpi;
-    //! use hydra_api::instruction::{CreateArgs, SchedMeta};
-    //!
-    //! // Inside your user-facing instruction's handler:
-    //! hydra_cpi::create(
-    //!     payer_ai, crank_ai, system_program_ai,
-    //!     &CreateArgs { seed, authority: [0u8; 32], /* ... */ },
-    //! )?;
-    //! ```
+pub mod base {
+    #[cfg(feature = "cpi-native")]
+    pub mod native {
+        //! CPI wrappers for `solana-program` / Anchor callers.
+        //!
+        //! # Example
+        //!
+        //! ```ignore
+        //! use hydra_api::cpi::native as hydra_cpi;
+        //! use hydra_api::instruction::{CreateArgs, SchedMeta};
+        //!
+        //! // Inside your user-facing instruction's handler:
+        //! hydra_cpi::create(
+        //!     payer_ai, crank_ai, system_program_ai,
+        //!     &CreateArgs { seed, authority: [0u8; 32], /* ... */ },
+        //!     &signer_seeds,
+        //! )?;
+        //! ```
 
-    use solana_account_info::AccountInfo;
-    use solana_cpi::{invoke, invoke_signed};
-    use solana_program_error::ProgramError;
+        use solana_account_info::AccountInfo;
+        use solana_cpi::invoke_signed;
+        use solana_program_error::ProgramError;
 
-    use crate::instruction as builder;
+        use crate::instruction::{base as builder, CreateArgs};
 
-    #[inline]
-    pub fn create<'a>(
-        payer: &AccountInfo<'a>,
-        crank: &AccountInfo<'a>,
-        system_program: &AccountInfo<'a>,
-        args: &builder::CreateArgs<'_>,
-    ) -> Result<(), ProgramError> {
-        let ix = builder::create(*payer.key, *crank.key, args);
-        invoke(&ix, &[payer.clone(), crank.clone(), system_program.clone()])
+        #[inline]
+        pub fn create<'a>(
+            payer: &AccountInfo<'a>,
+            crank: &AccountInfo<'a>,
+            system_program: &AccountInfo<'a>,
+            args: &CreateArgs<'_>,
+            signer_seeds: &[&[&[u8]]],
+        ) -> Result<(), ProgramError> {
+            let ix = builder::create(*payer.key, *crank.key, args);
+            invoke_signed(
+                &ix,
+                &[payer.clone(), crank.clone(), system_program.clone()],
+                signer_seeds,
+            )
+        }
+
+        /// `signer_seeds` is typically `&[&[b"authority_seed", &[bump]]]` when
+        /// `authority` is a PDA controlled by the integrator program, or
+        /// `&[]` when it's an EOA.
+        #[inline]
+        pub fn cancel<'a>(
+            authority: &AccountInfo<'a>,
+            crank: &AccountInfo<'a>,
+            recipient: &AccountInfo<'a>,
+            signer_seeds: &[&[&[u8]]],
+        ) -> Result<(), ProgramError> {
+            let ix = builder::cancel(*authority.key, *crank.key, *recipient.key);
+            invoke_signed(
+                &ix,
+                &[authority.clone(), crank.clone(), recipient.clone()],
+                signer_seeds,
+            )
+        }
+
+        /// `signer_seeds` is typically `&[]` unless the reporter is a PDA
+        /// owned by the integrator program.
+        #[inline]
+        pub fn close<'a>(
+            reporter: &AccountInfo<'a>,
+            crank: &AccountInfo<'a>,
+            recipient: &AccountInfo<'a>,
+            signer_seeds: &[&[&[u8]]],
+        ) -> Result<(), ProgramError> {
+            let ix = builder::close(*reporter.key, *crank.key, *recipient.key);
+            invoke_signed(
+                &ix,
+                &[reporter.clone(), crank.clone(), recipient.clone()],
+                signer_seeds,
+            )
+        }
     }
 
-    /// `signer_seeds` is typically `&[&[b"authority_seed", &[bump]]]` when
-    /// `authority` is a PDA controlled by the integrator program, or
-    /// `&[]` when it's an EOA.
-    #[inline]
-    pub fn cancel<'a>(
-        authority: &AccountInfo<'a>,
-        crank: &AccountInfo<'a>,
-        recipient: &AccountInfo<'a>,
-        signer_seeds: &[&[&[u8]]],
-    ) -> Result<(), ProgramError> {
-        let ix = builder::cancel(*authority.key, *crank.key, *recipient.key);
-        invoke_signed(
-            &ix,
-            &[authority.clone(), crank.clone(), recipient.clone()],
-            signer_seeds,
-        )
-    }
+    #[cfg(feature = "cpi-pinocchio")]
+    pub mod pinocchio {
+        //! CPI wrappers for Pinocchio callers.
+        //!
+        //! Build `Create` manually. See `examples/pinocchio/`.
 
-    /// `signer_seeds` is typically `&[]` unless the reporter is a PDA
-    /// owned by the integrator program.
-    #[inline]
-    pub fn close<'a>(
-        reporter: &AccountInfo<'a>,
-        crank: &AccountInfo<'a>,
-        recipient: &AccountInfo<'a>,
-        signer_seeds: &[&[&[u8]]],
-    ) -> Result<(), ProgramError> {
-        let ix = builder::close(*reporter.key, *crank.key, *recipient.key);
-        invoke_signed(
-            &ix,
-            &[reporter.clone(), crank.clone(), recipient.clone()],
-            signer_seeds,
-        )
+        use pinocchio::{
+            cpi::{invoke_signed, Signer},
+            instruction::{InstructionAccount, InstructionView},
+            AccountView, ProgramResult,
+        };
+        use solana_program_error::ProgramError;
+
+        use crate::instruction as builder;
+        use crate::{consts::ix as disc, instruction::CREATE_FIXED_PREFIX_LEN};
+
+        #[inline]
+        pub fn create<const N: usize>(
+            payer: &AccountView,
+            crank: &AccountView,
+            system_program: &AccountView,
+            args: &builder::CreateArgs<'_>,
+            signers: &[Signer],
+        ) -> ProgramResult {
+            if 1 + CREATE_FIXED_PREFIX_LEN + args.body_len() > N {
+                return Err(ProgramError::InvalidInstructionData);
+            }
+
+            let mut data = [0_u8; N];
+            let written = args.write_to(&mut data);
+
+            let ix = InstructionView {
+                program_id: &crate::base::ID,
+                accounts: &[
+                    InstructionAccount::writable_signer(payer.address()),
+                    InstructionAccount::writable(crank.address()),
+                    InstructionAccount::readonly(system_program.address()),
+                ],
+                data: &data[..written],
+            };
+
+            invoke_signed(&ix, &[payer, crank, system_program], signers)
+        }
+
+        #[inline(always)]
+        pub fn cancel(
+            authority: &AccountView,
+            crank: &AccountView,
+            recipient: &AccountView,
+            signers: &[Signer],
+        ) -> ProgramResult {
+            let data = [disc::CANCEL];
+            let metas = [
+                InstructionAccount::readonly_signer(authority.address()),
+                InstructionAccount::writable(crank.address()),
+                InstructionAccount::writable(recipient.address()),
+            ];
+            let ix = InstructionView {
+                program_id: &crate::base::ID,
+                accounts: &metas,
+                data: &data,
+            };
+            invoke_signed(&ix, &[authority, crank, recipient], signers)
+        }
+
+        #[inline(always)]
+        pub fn close(
+            reporter: &AccountView,
+            crank: &AccountView,
+            recipient: &AccountView,
+            signers: &[Signer],
+        ) -> ProgramResult {
+            let data = [disc::CLOSE];
+            let metas = [
+                InstructionAccount::writable_signer(reporter.address()),
+                InstructionAccount::writable(crank.address()),
+                InstructionAccount::writable(recipient.address()),
+            ];
+            let ix = InstructionView {
+                program_id: &crate::base::ID,
+                accounts: &metas,
+                data: &data,
+            };
+            invoke_signed(&ix, &[reporter, crank, recipient], signers)
+        }
     }
 }
 
-#[cfg(feature = "cpi-pinocchio")]
-pub mod pinocchio {
-    //! CPI wrappers for Pinocchio callers.
-    //!
-    //! Build `Create` manually. See `examples/pinocchio/`.
+#[cfg(feature = "ephemeral")]
+pub mod ephemeral {
+    #[cfg(feature = "cpi-native")]
+    pub mod native {
+        //! CPI wrappers for `solana-program` / Anchor callers.
+        //!
+        //! # Example
+        //!
+        //! ```ignore
+        //! use hydra_api::cpi::ephemeral::native as hydra_cpi;
+        //! use hydra_api::instruction::{CreateArgs, SchedMeta};
+        //!
+        //! // Inside your user-facing instruction's handler:
+        //! hydra_cpi::create(
+        //!     sponsor_ai, crank_ai, vault_ai, magic_program_ai,
+        //!     &CreateArgs { seed, authority: [0u8; 32], /* ... */ },
+        //! )?;
+        //! ```
 
-    use pinocchio::{
-        cpi::{invoke_signed, Signer},
-        instruction::{InstructionAccount, InstructionView},
-        AccountView, ProgramResult,
-    };
+        use solana_account_info::AccountInfo;
+        use solana_cpi::invoke_signed;
+        use solana_program_error::ProgramError;
 
-    use crate::consts::ix as disc;
+        use crate::instruction::{ephemeral as builder, CreateArgs};
 
-    #[inline(always)]
-    pub fn cancel(
-        authority: &AccountView,
-        crank: &AccountView,
-        recipient: &AccountView,
-        signers: &[Signer],
-    ) -> ProgramResult {
-        let data = [disc::CANCEL];
-        let metas = [
-            InstructionAccount::readonly_signer(authority.address()),
-            InstructionAccount::writable(crank.address()),
-            InstructionAccount::writable(recipient.address()),
-        ];
-        let ix = InstructionView {
-            program_id: &crate::base::ID,
-            accounts: &metas,
-            data: &data,
-        };
-        invoke_signed(&ix, &[authority, crank, recipient], signers)
+        #[inline]
+        pub fn create<'a>(
+            sponsor: &AccountInfo<'a>,
+            crank: &AccountInfo<'a>,
+            vault: &AccountInfo<'a>,
+            magic_program: &AccountInfo<'a>,
+            args: &CreateArgs<'_>,
+            signer_seeds: &[&[&[u8]]],
+        ) -> Result<(), ProgramError> {
+            let ix = builder::create(*sponsor.key, *crank.key, args);
+            invoke_signed(
+                &ix,
+                &[
+                    sponsor.clone(),
+                    crank.clone(),
+                    vault.clone(),
+                    magic_program.clone(),
+                ],
+                signer_seeds,
+            )
+        }
+
+        /// `signer_seeds` is typically `&[&[b"authority_seed", &[bump]]]` when
+        /// `authority` is a PDA controlled by the integrator program, or
+        /// `&[]` when it's an EOA.
+        #[inline]
+        pub fn cancel<'a>(
+            authority: &AccountInfo<'a>,
+            crank: &AccountInfo<'a>,
+            recipient: &AccountInfo<'a>,
+            vault: &AccountInfo<'a>,
+            magic_program: &AccountInfo<'a>,
+            signer_seeds: &[&[&[u8]]],
+        ) -> Result<(), ProgramError> {
+            let ix = builder::cancel(*authority.key, *crank.key, *recipient.key);
+            invoke_signed(
+                &ix,
+                &[
+                    authority.clone(),
+                    crank.clone(),
+                    recipient.clone(),
+                    vault.clone(),
+                    magic_program.clone(),
+                ],
+                signer_seeds,
+            )
+        }
+
+        /// `signer_seeds` is typically `&[]` unless the reporter is a PDA
+        /// owned by the integrator program.
+        #[inline]
+        pub fn close<'a>(
+            reporter: &AccountInfo<'a>,
+            crank: &AccountInfo<'a>,
+            recipient: &AccountInfo<'a>,
+            vault: &AccountInfo<'a>,
+            magic_program: &AccountInfo<'a>,
+            signer_seeds: &[&[&[u8]]],
+        ) -> Result<(), ProgramError> {
+            let ix = builder::close(*reporter.key, *crank.key, *recipient.key);
+            invoke_signed(
+                &ix,
+                &[
+                    reporter.clone(),
+                    crank.clone(),
+                    recipient.clone(),
+                    vault.clone(),
+                    magic_program.clone(),
+                ],
+                signer_seeds,
+            )
+        }
     }
 
-    #[inline(always)]
-    pub fn close(
-        reporter: &AccountView,
-        crank: &AccountView,
-        recipient: &AccountView,
-        signers: &[Signer],
-    ) -> ProgramResult {
-        let data = [disc::CLOSE];
-        let metas = [
-            InstructionAccount::writable_signer(reporter.address()),
-            InstructionAccount::writable(crank.address()),
-            InstructionAccount::writable(recipient.address()),
-        ];
-        let ix = InstructionView {
-            program_id: &crate::base::ID,
-            accounts: &metas,
-            data: &data,
+    #[cfg(feature = "cpi-pinocchio")]
+    pub mod pinocchio {
+        //! CPI wrappers for Pinocchio callers.
+        //!
+        //! Build `Create` manually. See `examples/pinocchio/`.
+
+        use pinocchio::{
+            cpi::{invoke_signed, Signer},
+            instruction::{InstructionAccount, InstructionView},
+            AccountView, ProgramResult,
         };
-        invoke_signed(&ix, &[reporter, crank, recipient], signers)
+        use solana_program_error::ProgramError;
+
+        use crate::{
+            consts::ix as disc,
+            instruction::{CreateArgs, CREATE_FIXED_PREFIX_LEN},
+        };
+
+        #[inline]
+        pub fn create<const N: usize>(
+            sponsor: &AccountView,
+            crank: &AccountView,
+            vault: &AccountView,
+            magic_program: &AccountView,
+            args: &CreateArgs<'_>,
+            signers: &[Signer],
+        ) -> ProgramResult {
+            if 1 + CREATE_FIXED_PREFIX_LEN + args.body_len() > N {
+                return Err(ProgramError::InvalidInstructionData);
+            }
+
+            let mut data = [0_u8; N];
+            let written = args.write_to(&mut data);
+
+            let ix = InstructionView {
+                program_id: &crate::ephemeral::ID,
+                data: &data[..written],
+                accounts: &[
+                    InstructionAccount::writable_signer(sponsor.address()),
+                    InstructionAccount::writable(crank.address()),
+                    InstructionAccount::writable(vault.address()),
+                    InstructionAccount::readonly(magic_program.address()),
+                ],
+            };
+            invoke_signed(&ix, &[sponsor, crank, vault, magic_program], signers)
+        }
+
+        #[inline(always)]
+        pub fn cancel(
+            authority: &AccountView,
+            crank: &AccountView,
+            recipient: &AccountView,
+            vault: &AccountView,
+            magic_program: &AccountView,
+            signers: &[Signer],
+        ) -> ProgramResult {
+            let data = [disc::CANCEL];
+            let metas = [
+                InstructionAccount::writable_signer(authority.address()),
+                InstructionAccount::writable(crank.address()),
+                InstructionAccount::writable(recipient.address()),
+                InstructionAccount::writable(vault.address()),
+                InstructionAccount::readonly(magic_program.address()),
+            ];
+            let ix = InstructionView {
+                program_id: &crate::ephemeral::ID,
+                accounts: &metas,
+                data: &data,
+            };
+            invoke_signed(
+                &ix,
+                &[authority, crank, recipient, vault, magic_program],
+                signers,
+            )
+        }
+
+        #[inline(always)]
+        pub fn close(
+            reporter: &AccountView,
+            crank: &AccountView,
+            recipient: &AccountView,
+            vault: &AccountView,
+            magic_program: &AccountView,
+            signers: &[Signer],
+        ) -> ProgramResult {
+            let data = [disc::CLOSE];
+            let metas = [
+                InstructionAccount::writable_signer(reporter.address()),
+                InstructionAccount::writable(crank.address()),
+                InstructionAccount::writable(recipient.address()),
+                InstructionAccount::writable(vault.address()),
+                InstructionAccount::readonly(magic_program.address()),
+            ];
+            let ix = InstructionView {
+                program_id: &crate::ephemeral::ID,
+                accounts: &metas,
+                data: &data,
+            };
+            invoke_signed(
+                &ix,
+                &[reporter, crank, recipient, vault, magic_program],
+                signers,
+            )
+        }
     }
 }

--- a/crates/hydra-api/src/instruction.rs
+++ b/crates/hydra-api/src/instruction.rs
@@ -349,8 +349,12 @@ mod client {
             }
         }
 
-        /// Build a `Close` instruction. `reporter` keeps the flat bounty (and the
-        /// vault rent refund); `recipient` receives the remaining balance.
+        /// Build a `Close` instruction. `recipient` receives the crank's
+        /// remaining balance; `reporter` receives the vault rent refund.
+        ///
+        /// Only unowned cranks (`authority == 0`) are permissionlessly
+        /// closable; for an owned crank, `reporter` and `recipient` must both
+        /// be its stored authority.
         pub fn close(reporter: Pubkey, crank: Pubkey, recipient: Pubkey) -> Instruction {
             Instruction {
                 program_id: PROGRAM_ID,

--- a/crates/hydra-api/src/instruction.rs
+++ b/crates/hydra-api/src/instruction.rs
@@ -39,6 +39,147 @@ pub const CREATE_FIXED_PREFIX_LEN: usize = 32 +  // seed
 /// `num_accounts: u8`, `data_len: u16 LE`, `program_id: [u8; 32]`.
 pub const CREATE_IX_HEADER_LEN: usize = 1 + 2 + 32; // = 35
 
+/// A scheduled-ix meta as it will be stored on-chain.
+///
+/// `is_signer` is intentionally absent: scheduled ixs cannot carry
+/// signer flags (enforced by `Create`), and the on-chain template
+/// stores only the writable bit anyway.
+#[derive(Clone, Copy)]
+pub struct SchedMeta {
+    pub pubkey: [u8; 32],
+    pub is_writable: bool,
+}
+
+impl SchedMeta {
+    pub fn readonly(pubkey: [u8; 32]) -> Self {
+        Self {
+            pubkey,
+            is_writable: false,
+        }
+    }
+    pub fn writable(pubkey: [u8; 32]) -> Self {
+        Self {
+            pubkey,
+            is_writable: true,
+        }
+    }
+}
+
+/// One scheduled instruction template.
+pub struct ScheduledIx<'a> {
+    pub program_id: [u8; 32],
+    pub metas: &'a [SchedMeta],
+    pub data: &'a [u8],
+}
+
+/// All the scheduling knobs for `Create`.
+///
+/// # Caller responsibilities (the program does NOT check these)
+///
+/// `Create` validates the wire format, the signer-flag ban, and a few
+/// numeric bounds, but it deliberately does **not** verify that the schedule
+/// is actually *crankable*. A schedule that violates any rule below is
+/// accepted and stored, but every `Trigger` will fail — the crank is created
+/// yet can never fire, stranding its rent. The client is the only party with
+/// the full account picture, so these are its responsibility:
+///
+/// 1. **Consistent writability per account.** If the same pubkey appears in
+///    more than one scheduled ix (or more than once in one ix), it must carry
+///    the *same* `is_writable` flag every time. The Solana runtime promotes an
+///    account to writable in *every* instruction region of the crank tx if it
+///    is writable in any of them; `Trigger` byte-matches the follow-up ix
+///    against the stored template, and a promoted `writable` flag can never
+///    match a stored `read-only` one.
+///
+/// 2. **The crank PDA is writable.** The crank PDA is writable in
+///    `Trigger` itself, so the runtime promotes it to writable everywhere.
+///    A scheduled program should authenticate the crank by reading
+///    the preceding `Trigger` from the instructions sysvar instead — not by
+///    listing the crank PDA as one of its own accounts.
+///
+/// 3. **Be careful referencing the cranker.** The cranker is the tx fee
+///    payer (signer + writable) and is unknown at schedule time, so any meta
+///    matching it is promoted and breaks the byte-match. Moreover, the cranker
+///    may refuse any cranks that includes its own pubkey as an account.
+pub struct CreateArgs<'a> {
+    pub seed: [u8; 32],
+    /// All-zeros = unkillable (no cancel authority).
+    pub authority: [u8; 32],
+    pub start_slot: u64,
+    pub interval_slots: u64,
+    /// `0` on the wire means "infinite"; Hydra stores `u64::MAX` internally.
+    pub remaining: u64,
+    pub priority_tip: u64,
+    /// Compute-unit limit the cranker emits as `SetComputeUnitLimit`
+    /// right before `Trigger`. `0` = no ix (inherits the 200 k/ix
+    /// default). Capped at `MAX_COMPUTE_UNIT_LIMIT` (1.4 M) at `Create`.
+    pub cu_limit: u32,
+    /// The scheduled instructions, in execution order. Must be non-empty
+    pub scheduled: &'a [ScheduledIx<'a>],
+}
+
+impl CreateArgs<'_> {
+    pub fn body_len(&self) -> usize {
+        self.scheduled
+            .iter()
+            .map(|s| CREATE_IX_HEADER_LEN + 33 * s.metas.len() + s.data.len())
+            .sum()
+    }
+
+    pub fn write_to(&self, data: &mut [u8]) -> usize {
+        let mut off = 0;
+
+        data[off] = ix::CREATE;
+        off += 1;
+
+        data[off..off + 32].copy_from_slice(&self.seed);
+        off += 32;
+
+        data[off..off + 32].copy_from_slice(&self.authority);
+        off += 32;
+
+        data[off..off + 8].copy_from_slice(&self.start_slot.to_le_bytes());
+        off += 8;
+
+        data[off..off + 8].copy_from_slice(&self.interval_slots.to_le_bytes());
+        off += 8;
+
+        data[off..off + 8].copy_from_slice(&self.remaining.to_le_bytes());
+        off += 8;
+
+        data[off..off + 8].copy_from_slice(&self.priority_tip.to_le_bytes());
+        off += 8;
+
+        data[off..off + 4].copy_from_slice(&self.cu_limit.to_le_bytes());
+        off += 4;
+
+        for s in self.scheduled {
+            data[off] = s.metas.len() as u8;
+            off += 1;
+
+            data[off..off + 2].copy_from_slice(&(s.data.len() as u16).to_le_bytes());
+            off += 2;
+
+            data[off..off + 32].copy_from_slice(&s.program_id);
+            off += 32;
+
+            for m in s.metas {
+                let flag: u8 = if m.is_writable { META_FLAG_WRITABLE } else { 0 };
+                data[off] = flag;
+                off += 1;
+
+                data[off..off + 32].copy_from_slice(&m.pubkey);
+                off += 32;
+            }
+
+            data[off..off + s.data.len()].copy_from_slice(s.data);
+            off += s.data.len();
+        }
+
+        off
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Client builders
 // ---------------------------------------------------------------------------
@@ -52,6 +193,9 @@ mod client {
     use solana_pubkey::{pubkey, Pubkey};
 
     use crate::consts::{ix, META_FLAG_WRITABLE};
+    use crate::instruction::CREATE_FIXED_PREFIX_LEN;
+
+    use super::*;
 
     /// Solana's built-in instructions sysvar pubkey.
     pub const INSTRUCTIONS_SYSVAR_ID: Pubkey =
@@ -60,186 +204,165 @@ mod client {
     /// Solana's system program pubkey.
     pub const SYSTEM_PROGRAM_ID: Pubkey = pubkey!("11111111111111111111111111111111");
 
+    /// The [`base`] / [`ephemeral`] programs.
+    pub const BASE_PROGRAM_ID: Pubkey = pubkey!("Hydra17i1feui9deaxu6d1TzSQMRNHeBRkDR1Awy7zea");
+    pub const EPHEMERAL_PROGRAM_ID: Pubkey = pubkey!("eHyd5BU8QffvHi4GnXwxrK4WpS7pM2x9UGKHBWii7mf");
+
     /// Hydra program ID as a `solana_pubkey::Pubkey` (convenience for clients).
-    pub fn program_id() -> Pubkey {
+    pub fn base_program_id() -> Pubkey {
         Pubkey::new_from_array(crate::base::ID.to_bytes())
     }
 
-    /// Derive the payer-bound `(crank_pda, bump)` using `solana_pubkey::Pubkey`.
-    pub fn find_crank_pda(payer: &Pubkey, seed: &[u8; 32]) -> (Pubkey, u8) {
-        let (addr, bump) = crate::state::find_base_crank_pda(payer.as_array(), seed);
-        (Pubkey::new_from_array(addr.to_bytes()), bump)
+    pub fn ephemeral_program_id() -> Pubkey {
+        Pubkey::new_from_array(crate::ephemeral::ID.to_bytes())
     }
 
-    /// Legacy unscoped derivation. Squattable by any payer.
-    // TODO: remove together with the legacy fallback in `Create`.
-    #[deprecated(note = "squattable; use the payer-bound `find_crank_pda`")]
-    pub fn find_crank_pda_unscoped(seed: &[u8; 32]) -> (Pubkey, u8) {
-        #[allow(deprecated)]
-        let (addr, bump) = crate::state::find_base_crank_pda_unscoped(seed);
-        (Pubkey::new_from_array(addr.to_bytes()), bump)
-    }
+    /// Builders targeting the base-layer Hydra program ([`BASE_PROGRAM_ID`]).
+    pub mod base {
 
-    /// A scheduled-ix meta as it will be stored on-chain.
-    ///
-    /// `is_signer` is intentionally absent: scheduled ixs cannot carry
-    /// signer flags (enforced by `Create`), and the on-chain template
-    /// stores only the writable bit anyway.
-    #[derive(Clone, Copy)]
-    pub struct SchedMeta {
-        pub pubkey: Pubkey,
-        pub is_writable: bool,
-    }
+        use super::*;
 
-    impl SchedMeta {
-        pub fn readonly(pubkey: Pubkey) -> Self {
-            Self {
-                pubkey,
-                is_writable: false,
+        /// This module's program ID.
+        pub const PROGRAM_ID: Pubkey = super::BASE_PROGRAM_ID;
+
+        /// Derive `(crank_pda, bump)` under the base program.
+        pub fn find_crank_pda(seed: &[u8; 32]) -> (Pubkey, u8) {
+            Pubkey::find_program_address(&[crate::consts::CRANK_SEED_PREFIX, seed], &PROGRAM_ID)
+        }
+
+        /// Build a `Create` instruction scheduling a single instruction.
+        pub fn create(payer: Pubkey, crank: Pubkey, args: &CreateArgs<'_>) -> Instruction {
+            let mut data = vec![0_u8; 1 + CREATE_FIXED_PREFIX_LEN + args.body_len()];
+            args.write_to(&mut data);
+
+            Instruction {
+                program_id: PROGRAM_ID,
+                accounts: alloc::vec![
+                    AccountMeta::new(payer, true),
+                    AccountMeta::new(crank, false),
+                    AccountMeta::new_readonly(SYSTEM_PROGRAM_ID, false),
+                ],
+                data,
             }
         }
-        pub fn writable(pubkey: Pubkey) -> Self {
-            Self {
-                pubkey,
-                is_writable: true,
+
+        /// Build a `Trigger` instruction. Must be paired in the same tx with the
+        /// scheduled instruction at `current_ix_index + 1`.
+        pub fn trigger(crank: Pubkey, cranker: Pubkey) -> Instruction {
+            Instruction {
+                program_id: PROGRAM_ID,
+                accounts: alloc::vec![
+                    AccountMeta::new(crank, false),
+                    AccountMeta::new(cranker, true),
+                    AccountMeta::new_readonly(INSTRUCTIONS_SYSVAR_ID, false),
+                ],
+                data: alloc::vec![ix::TRIGGER],
+            }
+        }
+
+        /// Build a `Cancel` instruction.
+        pub fn cancel(authority: Pubkey, crank: Pubkey, recipient: Pubkey) -> Instruction {
+            Instruction {
+                program_id: PROGRAM_ID,
+                accounts: alloc::vec![
+                    AccountMeta::new_readonly(authority, true),
+                    AccountMeta::new(crank, false),
+                    AccountMeta::new(recipient, false),
+                ],
+                data: alloc::vec![ix::CANCEL],
+            }
+        }
+
+        /// Build a `Close` instruction (permissionless cleanup).
+        pub fn close(reporter: Pubkey, crank: Pubkey, recipient: Pubkey) -> Instruction {
+            Instruction {
+                program_id: PROGRAM_ID,
+                accounts: alloc::vec![
+                    AccountMeta::new(reporter, true),
+                    AccountMeta::new(crank, false),
+                    AccountMeta::new(recipient, false),
+                ],
+                data: alloc::vec![ix::CLOSE],
             }
         }
     }
 
-    /// One scheduled instruction template.
-    pub struct ScheduledIx<'a> {
-        pub program_id: Pubkey,
-        pub metas: &'a [SchedMeta],
-        pub data: &'a [u8],
-    }
+    /// Builders targeting the ephemeral-rollup Hydra program
+    /// ([`EPHEMERAL_PROGRAM_ID`]).
+    #[cfg(feature = "ephemeral")]
+    pub mod ephemeral {
+        use ephemeral_rollups_pinocchio::consts::{EPHEMERAL_VAULT_ID, MAGIC_PROGRAM_ID};
 
-    /// All the scheduling knobs for `Create`.
-    ///
-    /// # Caller responsibilities (the program does NOT check these)
-    ///
-    /// `Create` validates the wire format, the signer-flag ban, and a few
-    /// numeric bounds, but it deliberately does **not** verify that the schedule
-    /// is actually *crankable*. A schedule that violates any rule below is
-    /// accepted and stored, but every `Trigger` will fail — the crank is created
-    /// yet can never fire, stranding its rent. The client is the only party with
-    /// the full account picture, so these are its responsibility:
-    ///
-    /// 1. **Consistent writability per account.** If the same pubkey appears in
-    ///    more than one scheduled ix (or more than once in one ix), it must carry
-    ///    the *same* `is_writable` flag every time. The Solana runtime promotes an
-    ///    account to writable in *every* instruction region of the crank tx if it
-    ///    is writable in any of them; `Trigger` byte-matches the follow-up ix
-    ///    against the stored template, and a promoted `writable` flag can never
-    ///    match a stored `read-only` one.
-    ///
-    /// 2. **The crank PDA is writable.** The crank PDA is writable in
-    ///    `Trigger` itself, so the runtime promotes it to writable everywhere.
-    ///    A scheduled program should authenticate the crank by reading
-    ///    the preceding `Trigger` from the instructions sysvar instead — not by
-    ///    listing the crank PDA as one of its own accounts.
-    ///
-    /// 3. **Be careful referencing the cranker.** The cranker is the tx fee
-    ///    payer (signer + writable) and is unknown at schedule time, so any meta
-    ///    matching it is promoted and breaks the byte-match. Moreover, the cranker
-    ///    may refuse any cranks that includes its own pubkey as an account.
-    pub struct CreateArgs<'a> {
-        pub seed: [u8; 32],
-        /// All-zeros = unkillable (no cancel authority).
-        pub authority: [u8; 32],
-        pub start_slot: u64,
-        pub interval_slots: u64,
-        /// `0` on the wire means "infinite"; Hydra stores `u64::MAX` internally.
-        pub remaining: u64,
-        pub priority_tip: u64,
-        /// Compute-unit limit the cranker emits as `SetComputeUnitLimit`
-        /// right before `Trigger`. `0` = no ix (inherits the 200 k/ix
-        /// default). Capped at `MAX_COMPUTE_UNIT_LIMIT` (1.4 M) at `Create`.
-        pub cu_limit: u32,
-        /// The scheduled instructions, in execution order. Must be non-empty
-        pub scheduled: &'a [ScheduledIx<'a>],
-    }
+        use super::*;
 
-    /// Build a `Create` instruction.
-    ///
-    /// This only serializes the wire format; it does not validate that the
-    /// schedule is crankable. See [`CreateArgs`] for the rules the caller must
-    /// uphold (consistent writability, crank/cranker metas) — a
-    /// schedule that breaks them is accepted on-chain but can never be triggered.
-    pub fn create(payer: Pubkey, crank: Pubkey, args: &CreateArgs<'_>) -> Instruction {
-        let body_len: usize = args
-            .scheduled
-            .iter()
-            .map(|s| super::CREATE_IX_HEADER_LEN + 33 * s.metas.len() + s.data.len())
-            .sum();
-        let mut data = Vec::with_capacity(1 + super::CREATE_FIXED_PREFIX_LEN + body_len);
-        data.push(ix::CREATE);
-        data.extend_from_slice(&args.seed);
-        data.extend_from_slice(&args.authority);
-        data.extend_from_slice(&args.start_slot.to_le_bytes());
-        data.extend_from_slice(&args.interval_slots.to_le_bytes());
-        data.extend_from_slice(&args.remaining.to_le_bytes());
-        data.extend_from_slice(&args.priority_tip.to_le_bytes());
-        data.extend_from_slice(&args.cu_limit.to_le_bytes());
-        for s in args.scheduled {
-            data.push(s.metas.len() as u8);
-            data.extend_from_slice(&(s.data.len() as u16).to_le_bytes());
-            data.extend_from_slice(&s.program_id.to_bytes());
-            for m in s.metas {
-                let flag: u8 = if m.is_writable { META_FLAG_WRITABLE } else { 0 };
-                data.push(flag);
-                data.extend_from_slice(&m.pubkey.to_bytes());
+        /// This module's program ID.
+        pub const PROGRAM_ID: Pubkey = super::EPHEMERAL_PROGRAM_ID;
+
+        /// Derive `(crank_pda, bump)` under the ephemeral program.
+        pub fn find_crank_pda(seed: &[u8; 32]) -> (Pubkey, u8) {
+            Pubkey::find_program_address(&[crate::consts::CRANK_SEED_PREFIX, seed], &PROGRAM_ID)
+        }
+
+        /// Build a `Create` instruction
+        pub fn create(sponsor: Pubkey, crank: Pubkey, args: &CreateArgs<'_>) -> Instruction {
+            let mut data = vec![0_u8; 1 + super::CREATE_FIXED_PREFIX_LEN + args.body_len()];
+            args.write_to(&mut data);
+
+            Instruction {
+                program_id: PROGRAM_ID,
+                accounts: alloc::vec![
+                    AccountMeta::new(sponsor, true),
+                    AccountMeta::new(crank, false),
+                    AccountMeta::new(EPHEMERAL_VAULT_ID, false),
+                    AccountMeta::new_readonly(MAGIC_PROGRAM_ID, false),
+                ],
+                data,
             }
-            data.extend_from_slice(s.data);
         }
 
-        Instruction {
-            program_id: program_id(),
-            accounts: alloc::vec![
-                AccountMeta::new(payer, true),
-                AccountMeta::new(crank, false),
-                AccountMeta::new_readonly(SYSTEM_PROGRAM_ID, false),
-            ],
-            data,
+        /// Build a `Trigger` instruction.
+        pub fn trigger(crank: Pubkey, cranker: Pubkey) -> Instruction {
+            Instruction {
+                program_id: PROGRAM_ID,
+                accounts: alloc::vec![
+                    AccountMeta::new(crank, false),
+                    AccountMeta::new(cranker, true),
+                    AccountMeta::new_readonly(INSTRUCTIONS_SYSVAR_ID, false),
+                ],
+                data: alloc::vec![ix::TRIGGER],
+            }
         }
-    }
 
-    /// Build a `Trigger` instruction. Must be paired in the same tx with the
-    /// scheduled instruction at `current_ix_index + 1`.
-    pub fn trigger(crank: Pubkey, cranker: Pubkey) -> Instruction {
-        Instruction {
-            program_id: program_id(),
-            accounts: alloc::vec![
-                AccountMeta::new(crank, false),
-                AccountMeta::new(cranker, true),
-                AccountMeta::new_readonly(INSTRUCTIONS_SYSVAR_ID, false),
-            ],
-            data: alloc::vec![ix::TRIGGER],
+        /// Build a `Cancel` instruction. `recipient` receives the crank's drained
+        /// lamport balance; the vault rent refunds to `authority`.
+        pub fn cancel(authority: Pubkey, crank: Pubkey, recipient: Pubkey) -> Instruction {
+            Instruction {
+                program_id: PROGRAM_ID,
+                accounts: alloc::vec![
+                    AccountMeta::new(authority, true),
+                    AccountMeta::new(crank, false),
+                    AccountMeta::new(recipient, false),
+                    AccountMeta::new(EPHEMERAL_VAULT_ID, false),
+                    AccountMeta::new_readonly(MAGIC_PROGRAM_ID, false),
+                ],
+                data: alloc::vec![ix::CANCEL],
+            }
         }
-    }
 
-    /// Build a `Cancel` instruction.
-    pub fn cancel(authority: Pubkey, crank: Pubkey, recipient: Pubkey) -> Instruction {
-        Instruction {
-            program_id: program_id(),
-            accounts: alloc::vec![
-                AccountMeta::new_readonly(authority, true),
-                AccountMeta::new(crank, false),
-                AccountMeta::new(recipient, false),
-            ],
-            data: alloc::vec![ix::CANCEL],
-        }
-    }
-
-    /// Build a `Close` instruction (permissionless cleanup).
-    pub fn close(reporter: Pubkey, crank: Pubkey, recipient: Pubkey) -> Instruction {
-        Instruction {
-            program_id: program_id(),
-            accounts: alloc::vec![
-                AccountMeta::new(reporter, true),
-                AccountMeta::new(crank, false),
-                AccountMeta::new(recipient, false),
-            ],
-            data: alloc::vec![ix::CLOSE],
+        /// Build a `Close` instruction. `reporter` keeps the flat bounty (and the
+        /// vault rent refund); `recipient` receives the remaining balance.
+        pub fn close(reporter: Pubkey, crank: Pubkey, recipient: Pubkey) -> Instruction {
+            Instruction {
+                program_id: PROGRAM_ID,
+                accounts: alloc::vec![
+                    AccountMeta::new(reporter, true),
+                    AccountMeta::new(crank, false),
+                    AccountMeta::new(recipient, false),
+                    AccountMeta::new(EPHEMERAL_VAULT_ID, false),
+                    AccountMeta::new_readonly(MAGIC_PROGRAM_ID, false),
+                ],
+                data: alloc::vec![ix::CLOSE],
+            }
         }
     }
 
@@ -306,3 +429,5 @@ mod client {
 
 #[cfg(feature = "client")]
 pub use client::*;
+
+use crate::{ix, META_FLAG_WRITABLE};

--- a/crates/hydra-cranker/src/fire.rs
+++ b/crates/hydra-cranker/src/fire.rs
@@ -62,7 +62,7 @@ pub fn fire_trigger(
 ) -> Result<()> {
     let scheduled = ix::scheduled_ixs_from_crank(&entry.data)
         .ok_or_else(|| anyhow!("malformed crank tail for {}", entry.pubkey))?;
-    let trigger = ix::trigger(entry.pubkey, cranker.pubkey());
+    let trigger = ix::base::trigger(entry.pubkey, cranker.pubkey());
     let blockhash = rpc.get_latest_blockhash().map_err(|e| {
         metrics::metrics()
             .rpc_errors_total
@@ -168,7 +168,7 @@ pub fn fire_close(
     } else {
         Pubkey::new_from_array(entry.authority)
     };
-    let close = ix::close(cranker.pubkey(), entry.pubkey, recipient);
+    let close = ix::base::close(cranker.pubkey(), entry.pubkey, recipient);
     let blockhash = rpc.get_latest_blockhash().map_err(|e| {
         metrics::metrics()
             .rpc_errors_total

--- a/crates/hydra-cranker/src/main.rs
+++ b/crates/hydra-cranker/src/main.rs
@@ -172,7 +172,7 @@ fn main() -> Result<()> {
     log::info!("rpc = {}", args.rpc_url);
     log::info!("ws  = {}", ws_url);
 
-    let program_id = ix::program_id();
+    let program_id = ix::base::PROGRAM_ID;
     let cache = new_cache();
     let shutdown = Arc::new(AtomicBool::new(false));
     // `at_slot` anchors each counter to an observed `next_exec_slot`: once

--- a/examples/anchor/programs/hydra-example-anchor/src/lib.rs
+++ b/examples/anchor/programs/hydra-example-anchor/src/lib.rs
@@ -9,11 +9,11 @@
 use anchor_lang::prelude::*;
 
 use hydra_api::{
-    cpi::native as hydra_cpi,
+    cpi::base::native as hydra_cpi,
     instruction::{CreateArgs, ScheduledIx},
 };
 
-declare_id!("Xyj597GykzwSu44muqNHtYs2aKUgm9ydNoHNySTDFs5");
+declare_id!("rgMuTEnEYWEK3EzqH9MkFthU9shDAPLgZX7dztEbBf4");
 
 #[program]
 pub mod hydra_example_anchor {
@@ -37,11 +37,12 @@ pub mod hydra_example_anchor {
                 priority_tip: 1_000,
                 cu_limit: 0, // no on-chain CU override
                 scheduled: &[ScheduledIx {
-                    program_id: target_program_id,
+                    program_id: target_program_id.to_bytes(),
                     metas: &[],
                     data: b"tick",
                 }],
             },
+            &[],
         )
         .map_err(Into::into)
     }

--- a/examples/native/src/lib.rs
+++ b/examples/native/src/lib.rs
@@ -22,7 +22,7 @@ use solana_program_error::{ProgramError, ProgramResult};
 use solana_pubkey::Pubkey;
 
 use hydra_api::{
-    cpi::native as hydra_cpi,
+    cpi::base::native as hydra_cpi,
     instruction::{CreateArgs, ScheduledIx},
 };
 
@@ -55,10 +55,11 @@ pub fn process_instruction(
             priority_tip: 1_000,
             cu_limit: 0, // no on-chain CU override
             scheduled: &[ScheduledIx {
-                program_id: target_program_id,
+                program_id: target_program_id.to_bytes(),
                 metas: &[],
                 data: b"tick",
             }],
         },
+        &[],
     )
 }

--- a/examples/pinocchio/src/lib.rs
+++ b/examples/pinocchio/src/lib.rs
@@ -5,15 +5,13 @@
 #![no_std]
 
 use pinocchio::{
-    cpi::invoke,
-    error::ProgramError,
-    instruction::{InstructionAccount, InstructionView},
-    no_allocator, nostd_panic_handler, program_entrypoint, AccountView, Address, ProgramResult,
+    error::ProgramError, no_allocator, nostd_panic_handler, program_entrypoint, AccountView,
+    Address, ProgramResult,
 };
 
 use hydra_api::{
-    consts::{ix as disc, MAX_ACCOUNTS, MAX_DATA_LEN},
-    instruction::{CREATE_FIXED_PREFIX_LEN, CREATE_IX_HEADER_LEN},
+    consts::{MAX_ACCOUNTS, MAX_DATA_LEN},
+    instruction::{CreateArgs, ScheduledIx, CREATE_FIXED_PREFIX_LEN, CREATE_IX_HEADER_LEN},
 };
 
 program_entrypoint!(process);
@@ -43,7 +41,9 @@ fn schedule(accounts: &[AccountView], data: &[u8]) -> ProgramResult {
     if data.len() < 66 {
         return Err(ProgramError::InvalidInstructionData);
     }
-    let seed = &data[0..32];
+    let seed: [u8; 32] = data[0..32]
+        .try_into()
+        .map_err(|_| ProgramError::InvalidInstructionData)?;
     let target_program_id = &data[32..64];
     let tick_len = u16::from_le_bytes([data[64], data[65]]) as usize;
     if data.len() < 66 + tick_len || tick_len > MAX_DATA_LEN {
@@ -51,48 +51,31 @@ fn schedule(accounts: &[AccountView], data: &[u8]) -> ProgramResult {
     }
     let tick_data = &data[66..66 + tick_len];
 
-    let [payer, crank, system_program, hydra_program, ..] = accounts else {
+    let [payer, crank, system_program, _hydra_program, ..] = accounts else {
         return Err(ProgramError::NotEnoughAccountKeys);
     };
 
     // Build Hydra Create data on the stack.
-    let mut buf = [0u8; CREATE_BUF_MAX];
-    let mut cursor = 0usize;
-    buf[cursor] = disc::CREATE;
-    cursor += 1;
-    buf[cursor..cursor + 32].copy_from_slice(seed);
-    cursor += 32;
-    buf[cursor..cursor + 32].copy_from_slice(&[0u8; 32]); // no cancel authority
-    cursor += 32;
-    buf[cursor..cursor + 8].copy_from_slice(&0u64.to_le_bytes()); // start_slot
-    cursor += 8;
-    buf[cursor..cursor + 8].copy_from_slice(&400u64.to_le_bytes()); // interval_slots
-    cursor += 8;
-    buf[cursor..cursor + 8].copy_from_slice(&10u64.to_le_bytes()); // remaining
-    cursor += 8;
-    buf[cursor..cursor + 8].copy_from_slice(&1_000u64.to_le_bytes()); // priority_tip
-    cursor += 8;
-    buf[cursor..cursor + 4].copy_from_slice(&0u32.to_le_bytes()); // cu_limit (omit)
-    cursor += 4;
-    buf[cursor] = 0; // num_accounts (single scheduled ix; parsed until data ends)
-    cursor += 1;
-    buf[cursor..cursor + 2].copy_from_slice(&(tick_len as u16).to_le_bytes());
-    cursor += 2;
-    buf[cursor..cursor + 32].copy_from_slice(target_program_id);
-    cursor += 32;
-    // No metas.
-    buf[cursor..cursor + tick_len].copy_from_slice(tick_data);
-    cursor += tick_len;
-
-    let metas = [
-        InstructionAccount::writable_signer(payer.address()),
-        InstructionAccount::writable(crank.address()),
-        InstructionAccount::readonly(system_program.address()),
-    ];
-    let ix = InstructionView {
-        program_id: hydra_program.address(),
-        accounts: &metas,
-        data: &buf[..cursor],
-    };
-    invoke(&ix, &[payer, crank, system_program])
+    hydra_api::cpi::base::pinocchio::create::<CREATE_BUF_MAX>(
+        payer,
+        crank,
+        system_program,
+        &CreateArgs {
+            seed,
+            authority: [0u8; 32],
+            start_slot: 0,
+            interval_slots: 400,
+            remaining: 10,
+            priority_tip: 1_000,
+            cu_limit: 0,
+            scheduled: &[ScheduledIx {
+                program_id: target_program_id
+                    .try_into()
+                    .map_err(|_| ProgramError::InvalidInstructionData)?,
+                metas: &[],
+                data: tick_data,
+            }],
+        },
+        &[],
+    )
 }

--- a/programs/hydra-ephemeral/Cargo.toml
+++ b/programs/hydra-ephemeral/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "hydra-ephemeral"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "Hydra — permissionless crank for MagicBlock ephemeral rollups"
+
+[lib]
+crate-type = ["cdylib"]
+
+[features]
+default = []
+# Gates all `pinocchio_log::log!` invocations at compile time so release
+# builds emit no log strings.
+logging = []
+# Skip the on-chain entrypoint when this crate is consumed as a library
+# (e.g. by integration tests that already loaded the .so separately).
+no-entrypoint = []
+
+[dependencies]
+pinocchio = { workspace = true }
+pinocchio-log = { workspace = true }
+# CPI helpers for MagicBlock ephemeral accounts — the funding model that
+# distinguishes this program from the base-layer `hydra` crate.
+ephemeral-rollups-pinocchio = { workspace = true }
+solana-define-syscall = { workspace = true }
+hydra-api = { workspace = true, features = ["program"] }
+
+[package.metadata.solana]
+program-id = "eHyd5BU8QffvHi4GnXwxrK4WpS7pM2x9UGKHBWii7mf"
+
+[lints]
+workspace = true

--- a/programs/hydra-ephemeral/src/entrypoint.rs
+++ b/programs/hydra-ephemeral/src/entrypoint.rs
@@ -1,0 +1,77 @@
+//! Program entrypoint and top-level discriminator dispatcher.
+
+use pinocchio::error::ProgramError;
+use pinocchio::{
+    no_allocator, nostd_panic_handler, program_entrypoint, AccountView, Address, ProgramResult,
+};
+
+use hydra_api::{consts::ix, HydraError};
+
+use crate::processor;
+
+program_entrypoint!(process_instruction);
+no_allocator!();
+nostd_panic_handler!();
+
+pub fn process_instruction(
+    _program_id: &Address,
+    accounts: &mut [AccountView],
+    instruction_data: &[u8],
+) -> ProgramResult {
+    inner_process_instruction(accounts, instruction_data).inspect_err(log_error)
+}
+
+#[inline(never)]
+fn inner_process_instruction(
+    accounts: &mut [AccountView],
+    instruction_data: &[u8],
+) -> ProgramResult {
+    let [discriminator, rest @ ..] = instruction_data else {
+        return Err(HydraError::InvalidInstruction.into());
+    };
+
+    match *discriminator {
+        ix::CREATE => {
+            #[cfg(feature = "logging")]
+            pinocchio_log::log!("ix: Create");
+            processor::create::process(accounts, rest)
+        }
+        ix::TRIGGER => {
+            #[cfg(feature = "logging")]
+            pinocchio_log::log!("ix: Trigger");
+            processor::trigger::process(accounts, rest)
+        }
+        ix::CANCEL => {
+            #[cfg(feature = "logging")]
+            pinocchio_log::log!("ix: Cancel");
+            processor::cancel::process(accounts, rest)
+        }
+        ix::CLOSE => {
+            #[cfg(feature = "logging")]
+            pinocchio_log::log!("ix: Close");
+            processor::close::process(accounts, rest)
+        }
+        _ => Err(HydraError::InvalidInstruction.into()),
+    }
+}
+
+#[cold]
+fn log_error(_error: &ProgramError) {
+    // When `logging` is off, this is a no-op: zero CU on the error path,
+    // and the raw `ProgramError` propagates to the runtime. When `logging`
+    // is on, emit the variant's name (including `HydraError::*` for Custom
+    // values) through the `sol_log_` syscall — no `format!`, no alloc.
+    #[cfg(feature = "logging")]
+    {
+        // `to_str` is an inherent method on `ProgramError` that internally
+        // calls `HydraError::to_str` (defined in hydra-api::error) for
+        // `ProgramError::Custom(n)` values.
+        let msg: &'static str = _error.to_str::<HydraError>();
+        #[cfg(target_os = "solana")]
+        // SAFETY: sol_log_ takes (ptr, len) of a byte buffer the syscall
+        // reads read-only for the duration of the call.
+        unsafe {
+            solana_define_syscall::definitions::sol_log_(msg.as_ptr(), msg.len() as u64);
+        }
+    }
+}

--- a/programs/hydra-ephemeral/src/entrypoint.rs
+++ b/programs/hydra-ephemeral/src/entrypoint.rs
@@ -66,12 +66,12 @@ fn log_error(_error: &ProgramError) {
         // `to_str` is an inherent method on `ProgramError` that internally
         // calls `HydraError::to_str` (defined in hydra-api::error) for
         // `ProgramError::Custom(n)` values.
-        let msg: &'static str = _error.to_str::<HydraError>();
+        let _msg: &'static str = _error.to_str::<HydraError>();
         #[cfg(target_os = "solana")]
         // SAFETY: sol_log_ takes (ptr, len) of a byte buffer the syscall
         // reads read-only for the duration of the call.
         unsafe {
-            solana_define_syscall::definitions::sol_log_(msg.as_ptr(), msg.len() as u64);
+            solana_define_syscall::definitions::sol_log_(_msg.as_ptr(), _msg.len() as u64);
         }
     }
 }

--- a/programs/hydra-ephemeral/src/lib.rs
+++ b/programs/hydra-ephemeral/src/lib.rs
@@ -1,0 +1,8 @@
+#![no_std]
+
+#[cfg(not(feature = "no-entrypoint"))]
+mod entrypoint;
+
+mod processor;
+
+pub use hydra_api::ephemeral::*;

--- a/programs/hydra-ephemeral/src/processor/cancel.rs
+++ b/programs/hydra-ephemeral/src/processor/cancel.rs
@@ -1,0 +1,28 @@
+//! `Cancel` (disc 2).
+//!
+//! Authority-gated drain of the crank's lamport balance to `recipient` (shared
+//! with base via `process_cancel`), then a Magic `CloseEphemeralAccount` CPI to
+//! deallocate the ephemeral account and refund its vault rent to `authority`.
+//!
+//! Accounts: `[authority(w,s), crank(w), recipient(w), vault(w), magic_program(ro)]`.
+
+use ephemeral_rollups_pinocchio::ephemeral_accounts::EphemeralAccount;
+use pinocchio::{error::ProgramError, AccountView, ProgramResult};
+
+use hydra_api::program::processor::process_cancel;
+
+use crate::processor::common::check_magic_accounts;
+
+pub fn process(accounts: &mut [AccountView], _data: &[u8]) -> ProgramResult {
+    let [authority, crank_ai, recipient, vault, magic_program] = accounts else {
+        return Err(ProgramError::NotEnoughAccountKeys);
+    };
+
+    check_magic_accounts(vault, magic_program)?;
+
+    process_cancel(authority, crank_ai, recipient, &crate::ID)?;
+
+    // Deallocate the now zero-lamport ephemeral account; Magic refunds the vault
+    // rent to `authority`.
+    EphemeralAccount::new(authority, crank_ai, vault, magic_program).close()
+}

--- a/programs/hydra-ephemeral/src/processor/close.rs
+++ b/programs/hydra-ephemeral/src/processor/close.rs
@@ -1,24 +1,28 @@
 //! `Close` (disc 3).
 //!
-//! Cleanup of an exhausted / underfunded / stuck ephemeral crank. Pays the
-//! cranker bounty to `reporter` and refunds the remaining balance to `recipient`
-//! (shared with base via `process_close`), then CPIs Magic
-//! `CloseEphemeralAccount` to deallocate the account and refund its vault rent.
+//! Cleanup of an exhausted / underfunded / stuck ephemeral crank. Refunds the
+//! remaining balance to `recipient` (shared with base via `process_close`),
+//! then CPIs Magic `CloseEphemeralAccount` to deallocate the account and refund
+//! its vault rent.
 //!
 //! Unlike the base `Close`, this is only permissionless for *unowned* cranks
 //! (`authority == 0`). When a crank carries a non-zero authority, only that
 //! authority may close it. The reason is the vault rent: Magic refunds it to the
 //! teardown's signer, so a permissionless close would hand an owned crank's rent
 //! to an arbitrary `reporter`. Gating owned cranks to their authority keeps the
-//! whole teardown — bounty, leftover balance, and vault rent — with the owner,
-//! while unowned cranks stay permissionlessly closable by anyone.
+//! whole teardown — leftover balance and vault rent — with the owner, while
+//! unowned cranks stay permissionlessly closable by anyone.
 //!
 //! Accounts: `[reporter(w,s), crank(w), recipient(w), vault(w), magic_program(ro)]`.
 
 use ephemeral_rollups_pinocchio::ephemeral_accounts::EphemeralAccount;
 use pinocchio::{error::ProgramError, AccountView, ProgramResult};
 
-use hydra_api::{program::processor::process_close, state::load_crank, HydraError};
+use hydra_api::{
+    program::processor::{process_close, require_signed_crank},
+    state::load_crank,
+    HydraError,
+};
 
 use crate::processor::common::check_magic_accounts;
 
@@ -28,6 +32,8 @@ pub fn process(accounts: &mut [AccountView], _data: &[u8]) -> ProgramResult {
     };
 
     check_magic_accounts(vault, magic_program)?;
+
+    require_signed_crank(reporter, crank_ai, &crate::ID)?;
 
     // A crank with an authority can only be closed by that authority: Magic
     // refunds the vault rent to the teardown's signer, so this keeps an owned

--- a/programs/hydra-ephemeral/src/processor/close.rs
+++ b/programs/hydra-ephemeral/src/processor/close.rs
@@ -1,0 +1,50 @@
+//! `Close` (disc 3).
+//!
+//! Cleanup of an exhausted / underfunded / stuck ephemeral crank. Pays the
+//! cranker bounty to `reporter` and refunds the remaining balance to `recipient`
+//! (shared with base via `process_close`), then CPIs Magic
+//! `CloseEphemeralAccount` to deallocate the account and refund its vault rent.
+//!
+//! Unlike the base `Close`, this is only permissionless for *unowned* cranks
+//! (`authority == 0`). When a crank carries a non-zero authority, only that
+//! authority may close it. The reason is the vault rent: Magic refunds it to the
+//! teardown's signer, so a permissionless close would hand an owned crank's rent
+//! to an arbitrary `reporter`. Gating owned cranks to their authority keeps the
+//! whole teardown — bounty, leftover balance, and vault rent — with the owner,
+//! while unowned cranks stay permissionlessly closable by anyone.
+//!
+//! Accounts: `[reporter(w,s), crank(w), recipient(w), vault(w), magic_program(ro)]`.
+
+use ephemeral_rollups_pinocchio::ephemeral_accounts::EphemeralAccount;
+use pinocchio::{error::ProgramError, AccountView, ProgramResult};
+
+use hydra_api::{program::processor::process_close, state::load_crank, HydraError};
+
+use crate::processor::common::check_magic_accounts;
+
+pub fn process(accounts: &mut [AccountView], _data: &[u8]) -> ProgramResult {
+    let [reporter, crank_ai, recipient, vault, magic_program] = accounts else {
+        return Err(ProgramError::NotEnoughAccountKeys);
+    };
+
+    check_magic_accounts(vault, magic_program)?;
+
+    // A crank with an authority can only be closed by that authority: Magic
+    // refunds the vault rent to the teardown's signer, so this keeps an owned
+    // crank's rent with its owner instead of an arbitrary reporter. Unowned
+    // cranks (`authority == 0`) stay permissionlessly closable.
+    let stored_authority = {
+        let data = crank_ai.try_borrow()?;
+        unsafe { load_crank(&data)? }.authority
+    };
+    if stored_authority != [0u8; 32] && reporter.address().as_array() != &stored_authority {
+        return Err(HydraError::UnauthorizedAuthority.into());
+    }
+
+    // Closable check + bounty/refund split, zeroes crank (ephemeral economics).
+    process_close(reporter, crank_ai, recipient, &crate::ID, true)?;
+
+    // Deallocate the now zero-lamport ephemeral account; Magic refunds the vault
+    // rent to `reporter` (== the authority for owned cranks, per the gate above).
+    EphemeralAccount::new(reporter, crank_ai, vault, magic_program).close()
+}

--- a/programs/hydra-ephemeral/src/processor/common.rs
+++ b/programs/hydra-ephemeral/src/processor/common.rs
@@ -1,0 +1,17 @@
+//! Helpers specific to the ephemeral-rollup crank processors.
+
+use ephemeral_rollups_pinocchio::consts::{EPHEMERAL_VAULT_ID, MAGIC_PROGRAM_ID};
+use pinocchio::{error::ProgramError, AccountView, ProgramResult};
+
+/// Reject calls that don't reference the real Magic program + ephemeral vault,
+/// so the CPI can't be pointed at an impostor program/vault.
+#[inline(always)]
+pub(super) fn check_magic_accounts(
+    vault: &AccountView,
+    magic_program: &AccountView,
+) -> ProgramResult {
+    if vault.address() != &EPHEMERAL_VAULT_ID || magic_program.address() != &MAGIC_PROGRAM_ID {
+        return Err(ProgramError::InvalidAccountData);
+    }
+    Ok(())
+}

--- a/programs/hydra-ephemeral/src/processor/create.rs
+++ b/programs/hydra-ephemeral/src/processor/create.rs
@@ -1,0 +1,82 @@
+//! `Create` (disc 0).
+//!
+//! Allocates the crank as a MagicBlock ephemeral account (owned by Hydra) via a
+//! Magic-program CPI — which materializes it synchronously — then writes the
+//! `Crank` header + scheduled-ix tail, all in one instruction.
+//!
+//! Accounts: `[sponsor(w,s), crank(w), vault(w), magic_program(ro)]`.
+//! Data: identical to base `Create`'s body (seed, authority, schedule, scheduled
+//! ixs). `sponsor` sets `authority_signer` and pays the per-byte ephemeral rent.
+
+use ephemeral_rollups_pinocchio::ephemeral_accounts::EphemeralAccount;
+use pinocchio::{
+    cpi::{Seed, Signer},
+    error::ProgramError,
+    AccountView, ProgramResult,
+};
+
+use hydra_api::consts::{CRANK_HEADER_SIZE, CRANK_SEED_PREFIX};
+use hydra_api::program::processor::{
+    derive_crank_pda, measure_region, parse_create_header, write_crank,
+};
+
+use crate::processor::common::check_magic_accounts;
+
+pub fn process(accounts: &mut [AccountView], data: &[u8]) -> ProgramResult {
+    let [sponsor, crank_ai, vault, magic_program] = accounts else {
+        return Err(ProgramError::NotEnoughAccountKeys);
+    };
+
+    let header = parse_create_header(data)?;
+    let authority_signer: u8 =
+        (sponsor.address().as_array() == &header.authority && sponsor.is_signer()) as u8;
+
+    check_magic_accounts(vault, magic_program)?;
+
+    // Size the account from the scheduled ixs (validates the schedule), then
+    // allocate it. The exact tail is written below.
+    let region_len = measure_region(data)?;
+    let (bump, payer_bound) = derive_crank_pda(
+        crank_ai,
+        sponsor.address().as_array(),
+        &header.seed,
+        &crate::ID,
+    )?;
+    let data_len = CRANK_HEADER_SIZE + region_len;
+
+    // The crank PDA must sign the create CPI (the ephemeral account is a signer
+    // on create, to prevent pubkey squatting); Hydra signs it with the seeds.
+    let bump_arr = [bump];
+    let payer_seeds = [
+        Seed::from(CRANK_SEED_PREFIX),
+        Seed::from(sponsor.address().as_array()),
+        Seed::from(header.seed.as_ref()),
+        Seed::from(&bump_arr),
+    ];
+    let legacy_seeds = [
+        Seed::from(CRANK_SEED_PREFIX),
+        Seed::from(header.seed.as_ref()),
+        Seed::from(&bump_arr),
+    ];
+    let signer = Signer::from(if payer_bound {
+        &payer_seeds[..]
+    } else {
+        &legacy_seeds[..]
+    });
+
+    EphemeralAccount::new(sponsor, crank_ai, vault, magic_program)
+        .with_signers(&[signer])
+        .create(data_len as u32)?;
+
+    // The account is sized to `region_len`, so `write_crank` fills it exactly.
+    // Ephemeral cranks hold no lamports, so the rent floor is `0`.
+    write_crank(
+        crank_ai,
+        data,
+        &header,
+        bump,
+        authority_signer,
+        0,
+        region_len,
+    )
+}

--- a/programs/hydra-ephemeral/src/processor/mod.rs
+++ b/programs/hydra-ephemeral/src/processor/mod.rs
@@ -1,0 +1,12 @@
+//! Ephemeral-rollup crank lifecycle.
+//!
+//! Schedule parsing, tail serialization and follow-up verification are shared
+//! with the base-layer program via [`hydra_api::program`]; only the MagicBlock
+//! ephemeral-account funding model lives here.
+
+pub mod cancel;
+pub mod close;
+pub mod create;
+pub mod trigger;
+
+mod common;

--- a/programs/hydra-ephemeral/src/processor/trigger.rs
+++ b/programs/hydra-ephemeral/src/processor/trigger.rs
@@ -1,0 +1,99 @@
+//! `Trigger` (disc 1).
+//!
+//! Runs a crank's scheduled ixs once, on the ephemeral rollup. Same top-level +
+//! instructions-sysvar + memcmp follow-up verification, cranker payout and
+//! schedule advance as base `Trigger`. The crank holds its reward budget as a
+//! plain lamport balance (funded by the sponsor); `rent_min` is `0` because the
+//! ephemeral account's rent lives in the Magic vault, not in the account.
+//!
+//! Accounts: `[crank(w), cranker(w,s), instructions_sysvar]`.
+
+use pinocchio::{
+    error::ProgramError, sysvars::instructions::INSTRUCTIONS_ID, AccountView, ProgramResult,
+};
+
+use hydra_api::{
+    consts::{ephemeral, REMAINING_INFINITE},
+    program::{
+        helpers::{get_clock_slot, get_stack_height, TRANSACTION_LEVEL_STACK_HEIGHT},
+        processor::verify_followup,
+    },
+    state::{load_crank, load_crank_mut},
+    HydraError,
+};
+
+pub fn process(accounts: &mut [AccountView], _data: &[u8]) -> ProgramResult {
+    let [crank_ai, cranker_ai, ix_sysvar_ai] = accounts else {
+        return Err(ProgramError::NotEnoughAccountKeys);
+    };
+
+    if !cranker_ai.is_signer() {
+        return Err(ProgramError::MissingRequiredSignature);
+    }
+    if !crank_ai.owned_by(&crate::ID) {
+        return Err(ProgramError::InvalidAccountOwner);
+    }
+    if ix_sysvar_ai.address() != &INSTRUCTIONS_ID {
+        return Err(ProgramError::UnsupportedSysvar);
+    }
+    if get_stack_height() != TRANSACTION_LEVEL_STACK_HEIGHT {
+        return Err(HydraError::InvalidInstruction.into());
+    }
+
+    let current_slot = get_clock_slot()?;
+
+    let (next_exec_slot, interval_slots, remaining, priority_tip, executed, region_len) = {
+        let data = crank_ai.try_borrow()?;
+        let s = unsafe { load_crank(&data)? };
+        (
+            s.next_exec_slot(),
+            s.interval_slots(),
+            s.remaining(),
+            s.priority_tip(),
+            s.executed(),
+            s.region_len(),
+        )
+    };
+
+    if current_slot < next_exec_slot {
+        return Err(HydraError::NotYetExecutable.into());
+    }
+    if remaining == 0 {
+        return Err(HydraError::Exhausted.into());
+    }
+
+    // Cranker reward, paid out of the crank's balance — same as base `Trigger`,
+    // but at the ephemeral-rollup rate.
+    let reward = ephemeral::CRANKER_REWARD
+        .checked_add(priority_tip)
+        .ok_or(ProgramError::ArithmeticOverflow)?;
+    let new_crank_lamports = crank_ai
+        .lamports()
+        .checked_sub(reward)
+        .ok_or::<ProgramError>(HydraError::InsufficientFunds.into())?;
+
+    verify_followup(ix_sysvar_ai, crank_ai, region_len as usize)?;
+
+    // Pay the cranker via direct lamport mutation.
+    crank_ai.set_lamports(new_crank_lamports);
+    let new_cranker_lamports = cranker_ai
+        .lamports()
+        .checked_add(reward)
+        .ok_or(ProgramError::ArithmeticOverflow)?;
+    cranker_ai.set_lamports(new_cranker_lamports);
+
+    let next_slot = next_exec_slot
+        .checked_add(interval_slots)
+        .ok_or(ProgramError::ArithmeticOverflow)?;
+    {
+        let mut data = crank_ai.try_borrow_mut()?;
+        let s = unsafe { load_crank_mut(&mut data)? };
+        s.set_next_exec_slot(next_slot);
+        s.set_executed(executed + 1);
+        if remaining != REMAINING_INFINITE {
+            s.set_remaining(remaining - 1);
+        }
+    }
+
+    Ok(())
+}

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -26,3 +26,4 @@ solana-system-interface = { workspace = true }
 
 [dev-dependencies]
 solana-logger = { workspace = true }
+ephemeral-rollups-pinocchio = { workspace = true }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -13,7 +13,7 @@ name = "compute_units"
 harness = false
 
 [dependencies]
-hydra-api = { workspace = true, features = ["client"] }
+hydra-api = { workspace = true, features = ["client", "ephemeral"] }
 # Tests reference hydra purely as a pre-built .so — load it via mollusk.
 # No `hydra` dependency here because we don't link on-chain code into tests.
 mollusk-svm = { workspace = true }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -26,6 +26,12 @@ use hydra_api::{
 /// Absolute path to the built `.so` (without extension) — mollusk appends `.so`.
 pub const HYDRA_SO: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../target/deploy/hydra");
 
+/// Absolute path to the built ephemeral `.so` (without extension).
+pub const HYDRA_EPHEMERAL_SO: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../target/deploy/hydra_ephemeral"
+);
+
 // ---------------------------------------------------------------------------
 // Helpers (pub so the bench file `benches/compute_units.rs` can reuse them)
 // ---------------------------------------------------------------------------
@@ -46,6 +52,16 @@ pub fn hydra_id() -> Pubkey {
 pub fn mollusk_with_hydra() -> Mollusk {
     let id = hydra_id();
     let mut mollusk = Mollusk::new(&id, HYDRA_SO);
+    memo::add_program(&mut mollusk);
+    mollusk
+}
+
+pub fn eph_id() -> Pubkey {
+    Pubkey::new_from_array(hydra_api::ephemeral::ID.to_bytes())
+}
+
+pub fn mollusk_with_hydra_ephemeral() -> Mollusk {
+    let mut mollusk = Mollusk::new(&eph_id(), HYDRA_EPHEMERAL_SO);
     memo::add_program(&mut mollusk);
     mollusk
 }
@@ -98,7 +114,7 @@ pub fn create_ix(
         priority_tip,
         cu_limit,
         &[ScheduledIx {
-            program_id: sched_program,
+            program_id: sched_program.to_bytes(),
             metas: sched_metas,
             data: sched_data,
         }],
@@ -136,7 +152,7 @@ pub fn create_ix_multi(
     for s in sched {
         data.push(s.metas.len() as u8);
         data.extend_from_slice(&(s.data.len() as u16).to_le_bytes());
-        data.extend_from_slice(&s.program_id.to_bytes());
+        data.extend_from_slice(&s.program_id);
         for meta in s.metas {
             let flag: u8 = if meta.is_writable {
                 META_FLAG_WRITABLE
@@ -144,7 +160,7 @@ pub fn create_ix_multi(
                 0
             };
             data.push(flag);
-            data.extend_from_slice(&meta.pubkey.to_bytes());
+            data.extend_from_slice(&meta.pubkey);
         }
         data.extend_from_slice(s.data);
     }
@@ -326,7 +342,7 @@ pub fn print_cu_table() {
     let payer_m = Pubkey::new_unique();
     let multi_specs: Vec<ScheduledIx> = (0..MULTI_N)
         .map(|_| ScheduledIx {
-            program_id: NOOP_ID,
+            program_id: NOOP_ID.to_bytes(),
             metas: &[],
             data: tick,
         })
@@ -488,7 +504,7 @@ pub fn print_cu_table() {
 #[cfg(test)]
 mod tests {
     use hydra_api::{
-        consts::base::{CRANKER_REWARD, STALENESS_THRESHOLD_SLOTS},
+        consts::{base, ephemeral},
         instruction::CreateArgs,
         state::region_len_for,
     };
@@ -513,7 +529,7 @@ mod tests {
         let scheduled_data: &[u8] = b"tick";
         let cu_limit: u32 = 321_000;
 
-        let ix = hydra_api::instruction::create(
+        let ix = hydra_api::instruction::base::create(
             payer,
             crank_pda,
             &CreateArgs {
@@ -525,8 +541,8 @@ mod tests {
                 priority_tip: 1_000,
                 cu_limit,
                 scheduled: &[ScheduledIx {
-                    program_id: memo::ID,
-                    metas: &[SchedMeta::writable(scheduled_meta)],
+                    program_id: memo::ID.to_bytes(),
+                    metas: &[SchedMeta::writable(scheduled_meta.to_bytes())],
                     data: scheduled_data,
                 }],
             },
@@ -583,7 +599,7 @@ mod tests {
             1_000,     // priority_tip
             0,         // cu_limit (0 = omit the ix)
             memo::ID,
-            &[SchedMeta::readonly(recipient)], // one read-only account just for content
+            &[SchedMeta::readonly(recipient.to_bytes())], // one read-only account just for content
             memo_data,
         );
 
@@ -853,11 +869,110 @@ mod tests {
 
         assert_eq!(
             cranker_acct.lamports,
-            cranker_starting + CRANKER_REWARD + priority_tip,
+            cranker_starting + base::CRANKER_REWARD + priority_tip,
             "cranker reward"
         );
 
         let header = decode_header(&crank_acct.data);
+        assert_eq!(header.executed(), 1, "executed++");
+        assert_eq!(header.remaining(), 9, "remaining--");
+        assert_eq!(header.next_exec_slot(), 100, "slot advanced by interval");
+    }
+
+    /// The ephemeral `Trigger` must pay the cranker exactly like the base one.
+    /// Ephemeral `Create` CPIs the Magic program (unavailable in mollusk), so we
+    /// mint a valid crank via the base program — the `Crank` layout + region are
+    /// identical — then re-own it to the ephemeral program and trigger it.
+    #[test]
+    fn ephemeral_trigger_pays_cranker() {
+        let base = mollusk_with_hydra();
+        let payer = Pubkey::new_unique();
+        let cranker = Pubkey::new_unique();
+        let (crank_pda, _bump) = find_crank(&SEED);
+        let memo_data: &[u8] = b"tick";
+        let priority_tip: u64 = 2_500;
+
+        let create = create_ix(
+            payer,
+            crank_pda,
+            SEED,
+            [0u8; 32],
+            0,
+            100,
+            10,
+            priority_tip,
+            0,
+            memo::ID,
+            &[],
+            memo_data,
+        );
+        let (system_program, system_program_acct) = keyed_account_for_system_program();
+        let (memo_id, memo_acct) = memo::keyed_account();
+        let create_accounts = vec![
+            (payer, Account::new(PAYER_LAMPORTS, 0, &system_program)),
+            (crank_pda, Account::default()),
+            (memo_id, memo_acct.clone()),
+            (system_program, system_program_acct.clone()),
+        ];
+        let after_create = base.process_transaction_instructions(&[create], &create_accounts);
+        assert!(
+            after_create.raw_result.is_ok(),
+            "base create failed: {:?}",
+            after_create.raw_result
+        );
+
+        // Re-own the freshly-minted crank to the ephemeral program and fund it
+        // as the cranker-reward budget (a sponsor would do this with a transfer).
+        let mut crank_acct = after_create
+            .resulting_accounts
+            .iter()
+            .find(|(k, _)| k == &crank_pda)
+            .map(|(_, a)| a.clone())
+            .expect("crank after create");
+        crank_acct.owner = eph_id();
+        crank_acct.lamports += 1_000_000;
+
+        let eph = mollusk_with_hydra_ephemeral();
+        let cranker_starting: u64 = 0;
+        let trigger = hydra_api::instruction::ephemeral::trigger(crank_pda, cranker);
+        let scheduled = Instruction {
+            program_id: memo::ID,
+            accounts: vec![],
+            data: memo_data.to_vec(),
+        };
+        let trigger_accounts = vec![
+            (crank_pda, crank_acct),
+            (cranker, Account::new(cranker_starting, 0, &system_program)),
+            (memo_id, memo_acct),
+            (system_program, system_program_acct),
+        ];
+
+        let after = eph.process_transaction_instructions(&[trigger, scheduled], &trigger_accounts);
+        assert!(
+            after.raw_result.is_ok(),
+            "ephemeral trigger failed: {:?}",
+            after.raw_result
+        );
+
+        let cranker_acct = after
+            .resulting_accounts
+            .iter()
+            .find(|(k, _)| k == &cranker)
+            .map(|(_, a)| a)
+            .expect("cranker after trigger");
+        assert_eq!(
+            cranker_acct.lamports,
+            cranker_starting + ephemeral::CRANKER_REWARD + priority_tip,
+            "ephemeral cranker reward"
+        );
+
+        let crank_after = after
+            .resulting_accounts
+            .iter()
+            .find(|(k, _)| k == &crank_pda)
+            .map(|(_, a)| a)
+            .expect("crank after trigger");
+        let header = decode_header(&crank_after.data);
         assert_eq!(header.executed(), 1, "executed++");
         assert_eq!(header.remaining(), 9, "remaining--");
         assert_eq!(header.next_exec_slot(), 100, "slot advanced by interval");
@@ -1198,7 +1313,7 @@ mod tests {
     #[test]
     fn close_permissionless_when_stuck() {
         let mut mollusk = mollusk_with_hydra();
-        mollusk.sysvars.clock.slot = STALENESS_THRESHOLD_SLOTS + 1;
+        mollusk.sysvars.clock.slot = base::STALENESS_THRESHOLD_SLOTS + 1;
 
         let payer = Pubkey::new_unique();
         let reporter = Pubkey::new_unique();
@@ -1648,12 +1763,12 @@ mod tests {
             0,
             &[
                 ScheduledIx {
-                    program_id: memo::ID,
-                    metas: &[SchedMeta::writable(acct_a)],
+                    program_id: memo::ID.to_bytes(),
+                    metas: &[SchedMeta::writable(acct_a.to_bytes())],
                     data: b"first",
                 },
                 ScheduledIx {
-                    program_id: memo::ID,
+                    program_id: memo::ID.to_bytes(),
                     metas: &[],
                     data: b"second",
                 },
@@ -1716,12 +1831,12 @@ mod tests {
             0,
             &[
                 ScheduledIx {
-                    program_id: memo::ID,
+                    program_id: memo::ID.to_bytes(),
                     metas: &[],
                     data: b"alpha",
                 },
                 ScheduledIx {
-                    program_id: memo::ID,
+                    program_id: memo::ID.to_bytes(),
                     metas: &[],
                     data: b"beta",
                 },
@@ -1780,7 +1895,7 @@ mod tests {
         // One Trigger = one reward + one schedule advance, regardless of ix count.
         assert_eq!(
             cranker_acct.lamports,
-            cranker_starting + CRANKER_REWARD + priority_tip,
+            cranker_starting + base::CRANKER_REWARD + priority_tip,
             "single reward per trigger"
         );
         let header = decode_header(&crank_acct.data);
@@ -1808,12 +1923,12 @@ mod tests {
             0,
             &[
                 ScheduledIx {
-                    program_id: memo::ID,
+                    program_id: memo::ID.to_bytes(),
                     metas: &[],
                     data: b"alpha",
                 },
                 ScheduledIx {
-                    program_id: memo::ID,
+                    program_id: memo::ID.to_bytes(),
                     metas: &[],
                     data: b"beta",
                 },
@@ -1869,12 +1984,12 @@ mod tests {
             0,
             &[
                 ScheduledIx {
-                    program_id: memo::ID,
+                    program_id: memo::ID.to_bytes(),
                     metas: &[],
                     data: b"alpha",
                 },
                 ScheduledIx {
-                    program_id: memo::ID,
+                    program_id: memo::ID.to_bytes(),
                     metas: &[],
                     data: b"beta",
                 },
@@ -1924,12 +2039,12 @@ mod tests {
             0,
             &[
                 ScheduledIx {
-                    program_id: memo::ID,
+                    program_id: memo::ID.to_bytes(),
                     metas: &[],
                     data: b"alpha",
                 },
                 ScheduledIx {
-                    program_id: memo::ID,
+                    program_id: memo::ID.to_bytes(),
                     metas: &[],
                     data: b"beta",
                 },
@@ -2060,7 +2175,7 @@ mod tests {
         // Exactly MAX_INSTRUCTIONS tiny memos -> ok.
         let at_max: Vec<ScheduledIx> = (0..MAX_INSTRUCTIONS)
             .map(|_| ScheduledIx {
-                program_id: memo::ID,
+                program_id: memo::ID.to_bytes(),
                 metas: &[],
                 data: b"m",
             })
@@ -2086,7 +2201,7 @@ mod tests {
         // One past the cap -> rejected.
         let over: Vec<ScheduledIx> = (0..MAX_INSTRUCTIONS + 1)
             .map(|_| ScheduledIx {
-                program_id: memo::ID,
+                program_id: memo::ID.to_bytes(),
                 metas: &[],
                 data: b"m",
             })
@@ -2139,12 +2254,12 @@ mod tests {
             0,
             &[
                 ScheduledIx {
-                    program_id: NOOP_ID,
-                    metas: &[SchedMeta::writable(writable_acct)],
+                    program_id: NOOP_ID.to_bytes(),
+                    metas: &[SchedMeta::writable(writable_acct.to_bytes())],
                     data: b"one",
                 },
                 ScheduledIx {
-                    program_id: NOOP_ID,
+                    program_id: NOOP_ID.to_bytes(),
                     metas: &[],
                     data: b"two",
                 },

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -503,11 +503,13 @@ pub fn print_cu_table() {
 
 #[cfg(test)]
 mod tests {
+    use ephemeral_rollups_pinocchio::consts::{EPHEMERAL_VAULT_ID, MAGIC_PROGRAM_ID};
     use hydra_api::{
         consts::{base, ephemeral},
         instruction::CreateArgs,
         state::region_len_for,
     };
+    use mollusk_svm::result::types::TransactionProgramResult;
 
     use super::*;
 
@@ -976,6 +978,106 @@ mod tests {
         assert_eq!(header.executed(), 1, "executed++");
         assert_eq!(header.remaining(), 9, "remaining--");
         assert_eq!(header.next_exec_slot(), 100, "slot advanced by interval");
+    }
+
+    #[test]
+    fn ephemeral_close_gates_owned_cranks_to_their_authority() {
+        const UNAUTHORIZED_AUTHORITY: u64 = 4;
+        const NOT_CLOSABLE: u64 = 5;
+
+        // A crank minted by the base program, re-owned to the ephemeral one —
+        // same trick as `ephemeral_trigger_pays_cranker`, since ephemeral
+        // `Create` needs the Magic program that mollusk doesn't have.
+        let mint_eph_crank = |authority: [u8; 32]| -> Account {
+            let base = mollusk_with_hydra();
+            let payer = Pubkey::new_unique();
+            let (crank_pda, _bump) = find_crank(&SEED);
+            let create = create_ix(
+                payer,
+                crank_pda,
+                SEED,
+                authority,
+                0,   // start_slot
+                100, // interval_slots
+                10,  // remaining — not exhausted
+                0,   // priority_tip — keeps `underfunded` false at the base rent floor
+                0,   // cu_limit
+                memo::ID,
+                &[],
+                b"tick",
+            );
+            let (system_program, system_program_acct) = keyed_account_for_system_program();
+            let (memo_id, memo_acct) = memo::keyed_account();
+            let accounts = vec![
+                (payer, Account::new(PAYER_LAMPORTS, 0, &system_program)),
+                (crank_pda, Account::default()),
+                (memo_id, memo_acct),
+                (system_program, system_program_acct),
+            ];
+            let after = base.process_transaction_instructions(&[create], &accounts);
+            assert!(
+                after.raw_result.is_ok(),
+                "base create failed: {:?}",
+                after.raw_result
+            );
+            let mut crank_acct = after
+                .resulting_accounts
+                .into_iter()
+                .find(|(k, _)| k == &crank_pda)
+                .map(|(_, a)| a)
+                .expect("crank after create");
+            crank_acct.owner = eph_id();
+            crank_acct
+        };
+
+        let eph = mollusk_with_hydra_ephemeral();
+        let (crank_pda, _bump) = find_crank(&SEED);
+        let (system_program, system_program_acct) = keyed_account_for_system_program();
+        let vault = Pubkey::new_from_array(EPHEMERAL_VAULT_ID.to_bytes());
+        let magic = Pubkey::new_from_array(MAGIC_PROGRAM_ID.to_bytes());
+
+        let run = |crank_acct: Account, reporter: Pubkey, recipient: Pubkey| {
+            let close = hydra_api::instruction::ephemeral::close(reporter, crank_pda, recipient);
+            let accounts = vec![
+                (reporter, Account::new(0, 0, &system_program)),
+                (crank_pda, crank_acct),
+                (recipient, Account::new(0, 0, &system_program)),
+                (vault, Account::default()),
+                (magic, Account::default()),
+                (system_program, system_program_acct.clone()),
+            ];
+            match eph
+                .process_transaction_instructions(&[close], &accounts)
+                .program_result
+            {
+                TransactionProgramResult::Failure(_, err) => u64::from(err),
+                other => panic!("expected a program failure, got {other:?}"),
+            }
+        };
+
+        // 1. Owned crank, wrong reporter -> stopped by the gate.
+        let authority = Pubkey::new_unique();
+        let imposter = Pubkey::new_unique();
+        let code = run(mint_eph_crank(authority.to_bytes()), imposter, authority);
+        assert_eq!(
+            code, UNAUTHORIZED_AUTHORITY,
+            "imposter must be stopped by the authority gate"
+        );
+
+        // 2. Owned crank, the authority itself -> past the gate.
+        let code = run(mint_eph_crank(authority.to_bytes()), authority, authority);
+        assert_eq!(
+            code, NOT_CLOSABLE,
+            "the authority should clear the gate and be stopped by the closable check"
+        );
+
+        // 3. Unowned crank, arbitrary reporter -> past the gate, still permissionless.
+        let recipient = Pubkey::new_unique();
+        let code = run(mint_eph_crank([0u8; 32]), imposter, recipient);
+        assert_eq!(
+            code, NOT_CLOSABLE,
+            "unowned cranks must stay permissionlessly closable"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #25

Second program (eHyd5BU8QffvHi4GnXwxrK4WpS7pM2x9UGKHBWii7mf) targeting
MagicBlock ephemeral rollups: zero base fee, tip-funded cranker rewards
and delegation-aware close/cancel. Shares the processor core with
programs/hydra via hydra-api::program; only the funding model differs.

Splits the client surface into instruction::{base,ephemeral} and
cpi::{base,ephemeral}. The cranker follows the base builders here; mode
selection lands in a follow-up.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>