### PR TITLE
feat(cranker): drive ephemeral cranks

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,7 +259,9 @@ hydra-cranker \
 # `--rpc-url` points at the rollup; `--base-rpc-url` is required alongside it,
 # because the cranker delegates its own keypair at startup so the rollup will
 # let its balance change as the trigger fee payer, and delegating is a
-# base-layer transaction.
+# base-layer transaction. On shutdown it releases that delegation — but only if
+# it was the one to take it; a keypair already delegated at startup is left
+# alone, since something else owns that delegation.
 hydra-cranker \
   --keypair ~/.config/solana/cranker.json \
   --rpc-url https://your.rollup.example \

--- a/README.md
+++ b/README.md
@@ -253,6 +253,19 @@ hydra-cranker \
   --rpc-url https://your.rpc.example \
   --ws-url wss://your.rpc.example
 
+# Against a MagicBlock ephemeral rollup. `--ephemeral` switches the target
+# program, the `Close` account layout, and the (zero-lamport) funding model at
+# runtime — the same binary drives either program, no rebuild needed.
+# `--rpc-url` points at the rollup; `--base-rpc-url` is required alongside it,
+# because the cranker delegates its own keypair at startup so the rollup will
+# let its balance change as the trigger fee payer, and delegating is a
+# base-layer transaction.
+hydra-cranker \
+  --keypair ~/.config/solana/cranker.json \
+  --rpc-url https://your.rollup.example \
+  --base-rpc-url https://your.rpc.example \
+  --ephemeral
+
 # With Prometheus metrics at http://0.0.0.0:9100/metrics
 # and JSON health at http://0.0.0.0:9100/healthz
 hydra-cranker \

--- a/README.md
+++ b/README.md
@@ -259,9 +259,11 @@ hydra-cranker \
 # `--rpc-url` points at the rollup; `--base-rpc-url` is required alongside it,
 # because the cranker delegates its own keypair at startup so the rollup will
 # let its balance change as the trigger fee payer, and delegating is a
-# base-layer transaction. On shutdown it releases that delegation — but only if
-# it was the one to take it; a keypair already delegated at startup is left
-# alone, since something else owns that delegation.
+# base-layer transaction. If the delegation is later released out from under it
+# — triggers start failing with `InvalidAccountForFee` — the cranker re-delegates
+# itself and carries on. On shutdown it releases that delegation, but only if it
+# was the one to take it; a keypair already delegated at startup is left alone,
+# since something else owns that delegation.
 hydra-cranker \
   --keypair ~/.config/solana/cranker.json \
   --rpc-url https://your.rollup.example \

--- a/crates/hydra-cranker/Cargo.toml
+++ b/crates/hydra-cranker/Cargo.toml
@@ -11,7 +11,9 @@ name = "hydra-cranker"
 path = "src/main.rs"
 
 [dependencies]
-hydra-api = { workspace = true, features = ["client"] }
+hydra-api = { workspace = true, features = ["client", "ephemeral"] }
+ephemeral-rollups-sdk = { version = "0.16", features = ["instruction"] }
+solana-system-interface = { workspace = true }
 
 anyhow = "1"
 clap = { version = "4", features = ["derive", "env"] }
@@ -20,12 +22,14 @@ ctrlc = "3"
 env_logger = "0.11"
 log = "0.4"
 prometheus = { version = "0.13", default-features = false }
+serde_json = "1"
 tiny_http = "0.12"
 
 solana-client = "=4.0.0-beta.7"
 solana-pubsub-client = "=4.0.0-beta.7"
 solana-rpc-client-api = "=4.0.0-beta.7"
 solana-account-decoder-client-types = "=4.0.0-beta.7"
+solana-transaction-status-client-types = "=4.0.0-beta.7"
 
 solana-pubkey = { workspace = true }
 solana-commitment-config = "3.1"

--- a/crates/hydra-cranker/src/cache.rs
+++ b/crates/hydra-cranker/src/cache.rs
@@ -99,6 +99,19 @@ impl CrankEntry {
         })
     }
 
+    /// The newest `next_exec_slot` the *chain* has reported: `next_exec_slot`
+    /// with any still-unconfirmed local advance backed out.
+    ///
+    /// Failure bookkeeping keys on this rather than on `next_exec_slot`, so an
+    /// accepted-but-dropped submit cannot pass for on-chain progress and reset
+    /// a crank's consecutive-failure count.
+    pub fn confirmed_next_exec_slot(&self) -> u64 {
+        match self.optimistic {
+            Some(o) => o.prev_next_exec_slot,
+            None => self.next_exec_slot,
+        }
+    }
+
     /// Mirrors Hydra's on-chain Trigger pre-flight: slot reached, not
     /// exhausted, enough lamports to cover reward + tip above the rent floor.
     pub fn is_eligible(&self, current_slot: u64) -> bool {
@@ -426,6 +439,22 @@ mod tests {
         assert!(
             rearm_unconfirmed(&cache, 200, 30).is_empty(),
             "re-arming is one-shot"
+        );
+    }
+
+    #[test]
+    fn an_optimistic_advance_is_not_confirmed_progress() {
+        let cache = new_cache();
+        let pk = seed(&cache, entry(100, 5, 5));
+        advance_after_trigger(&cache, pk, 100, 100);
+
+        let g = cache.lock().unwrap();
+        let e = g.get(&pk).unwrap();
+        assert_eq!(e.next_exec_slot, 105, "the schedule moved for firing");
+        assert_eq!(
+            e.confirmed_next_exec_slot(),
+            100,
+            "but a failure record taken at 100 must not read as stale"
         );
     }
 

--- a/crates/hydra-cranker/src/cache.rs
+++ b/crates/hydra-cranker/src/cache.rs
@@ -38,6 +38,20 @@ pub struct CrankEntry {
     /// `0` = cranker omits `SetComputeUnitLimit`.
     pub cu_limit: u32,
     pub data: Vec<u8>,
+    /// Set while `next_exec_slot` holds a locally-replayed `Trigger` advance
+    /// that no on-chain update has confirmed yet. Always `None` on an entry
+    /// decoded from account bytes, so any authoritative update clears it.
+    pub optimistic: Option<Optimistic>,
+}
+
+/// A `Trigger` advance applied to the cache on submit, before the chain has
+/// confirmed it. Kept so the advance can be undone if it never lands.
+#[derive(Clone, Copy)]
+pub struct Optimistic {
+    /// `next_exec_slot` before the advance, restored on re-arm.
+    pub prev_next_exec_slot: u64,
+    /// Slot the advance was applied at; the re-arm window runs from here.
+    pub at_slot: u64,
 }
 
 fn cranker_reward() -> u64 {
@@ -81,6 +95,7 @@ impl CrankEntry {
             rent_min,
             cu_limit,
             data: data.to_vec(),
+            optimistic: None,
         })
     }
 
@@ -187,7 +202,11 @@ pub enum CacheOutcome {
 /// double-advance. A late, *pre*-trigger notification can still overwrite this with
 /// a stale value — that self-heals, because the next fire then lands as
 /// `NotYetExecutable` and the caller's backoff absorbs it.
-pub fn advance_after_trigger(cache: &Cache, pubkey: Pubkey, fired_at_next_exec: u64) {
+///
+/// The advance is only a guess — an accepted submit is not a landed transaction —
+/// so it is recorded as [`Optimistic`] and undone by [`rearm_unconfirmed`] if no
+/// on-chain update ever confirms it.
+pub fn advance_after_trigger(cache: &Cache, pubkey: Pubkey, fired_at_next_exec: u64, slot: u64) {
     let mut guard = cache.lock().expect("cache poisoned");
     if let Some(e) = guard.get_mut(&pubkey) {
         // Only the entry we actually fired on; a newer echo supersedes us.
@@ -195,7 +214,39 @@ pub fn advance_after_trigger(cache: &Cache, pubkey: Pubkey, fired_at_next_exec: 
             return;
         }
         e.next_exec_slot = e.next_exec_slot.saturating_add(e.interval_slots);
+        e.optimistic = Some(Optimistic {
+            prev_next_exec_slot: fired_at_next_exec,
+            at_slot: slot,
+        });
     }
+}
+
+/// Undo optimistic advances that no on-chain update has confirmed within
+/// `limit` slots, and return the cranks re-armed.
+///
+/// A submitted `Trigger` can be dropped after the RPC accepts it (a blockhash
+/// race, a leader drop, congestion — and with preflight on there is no
+/// confirmation at all). Nothing then changes on-chain, so no
+/// `programSubscribe` notification ever arrives to correct the cache, and
+/// without this the crank would sit out a full `interval_slots` — hours, for a
+/// long-interval crank — on a fire that never happened.
+///
+/// Re-arming an advance that *did* land is harmless: the crank is simply
+/// re-offered once its real `next_exec_slot` has passed, and an early re-fire
+/// reverts as `NotYetExecutable` into the caller's backoff.
+pub fn rearm_unconfirmed(cache: &Cache, current_slot: u64, limit: u64) -> Vec<Pubkey> {
+    let mut guard = cache.lock().expect("cache poisoned");
+    let mut rearmed = Vec::new();
+    for (pk, e) in guard.iter_mut() {
+        let Some(opt) = e.optimistic else { continue };
+        if current_slot.saturating_sub(opt.at_slot) < limit {
+            continue;
+        }
+        e.next_exec_slot = opt.prev_next_exec_slot;
+        e.optimistic = None;
+        rearmed.push(*pk);
+    }
+    rearmed
 }
 
 /// Apply a single account update to the cache. Removes entries that have
@@ -264,6 +315,7 @@ mod tests {
             rent_min: 0,
             cu_limit: 0,
             data: Vec::new(),
+            optimistic: None,
         }
     }
 
@@ -283,7 +335,7 @@ mod tests {
     fn advance_replays_the_schedule_but_not_the_countdown() {
         let cache = new_cache();
         let pk = seed(&cache, entry(100, 5, 3));
-        advance_after_trigger(&cache, pk, 100);
+        advance_after_trigger(&cache, pk, 100, 100);
         assert_eq!(
             snapshot(&cache, &pk),
             (105, 3),
@@ -296,7 +348,7 @@ mod tests {
         mode::init(false);
         let cache = new_cache();
         let pk = seed(&cache, entry(100, 5, 1));
-        advance_after_trigger(&cache, pk, 100);
+        advance_after_trigger(&cache, pk, 100, 100);
         assert_eq!(snapshot(&cache, &pk), (105, 1), "remaining stays 1");
         let g = cache.lock().unwrap();
         let e = g.get(&pk).unwrap();
@@ -332,7 +384,7 @@ mod tests {
         // A `programSubscribe` update landed first, advancing the entry to 105.
         let pk = seed(&cache, entry(105, 5, 2));
         // We fired on the older snapshot (100); the guard must not double-advance.
-        advance_after_trigger(&cache, pk, 100);
+        advance_after_trigger(&cache, pk, 100, 100);
         assert_eq!(
             snapshot(&cache, &pk),
             (105, 2),
@@ -344,11 +396,57 @@ mod tests {
     fn advance_keeps_the_infinite_remaining_sentinel() {
         let cache = new_cache();
         let pk = seed(&cache, entry(100, 1, REMAINING_INFINITE));
-        advance_after_trigger(&cache, pk, 100);
+        advance_after_trigger(&cache, pk, 100, 100);
         assert_eq!(
             snapshot(&cache, &pk),
             (101, REMAINING_INFINITE),
             "infinite cranks advance the schedule but never decrement remaining"
+        );
+    }
+
+    #[test]
+    fn unconfirmed_advance_is_undone_once_the_window_lapses() {
+        let cache = new_cache();
+        let pk = seed(&cache, entry(100, 1_000, 5));
+        advance_after_trigger(&cache, pk, 100, 100);
+        assert_eq!(snapshot(&cache, &pk), (1_100, 5));
+
+        assert!(
+            rearm_unconfirmed(&cache, 129, 30).is_empty(),
+            "still inside the window; the echo may yet arrive"
+        );
+        assert_eq!(snapshot(&cache, &pk), (1_100, 5));
+
+        assert_eq!(rearm_unconfirmed(&cache, 130, 30), vec![pk]);
+        assert_eq!(
+            snapshot(&cache, &pk),
+            (100, 5),
+            "a submit that never landed must not cost a whole interval"
+        );
+        assert!(
+            rearm_unconfirmed(&cache, 200, 30).is_empty(),
+            "re-arming is one-shot"
+        );
+    }
+
+    #[test]
+    fn a_confirmed_advance_is_never_re_armed() {
+        let cache = new_cache();
+        let pk = seed(&cache, entry(100, 1_000, 5));
+        advance_after_trigger(&cache, pk, 100, 100);
+
+        // The `programSubscribe` echo lands: the entry is rebuilt from account
+        // bytes, which clears the optimistic marker.
+        let mut raw = vec![0u8; CRANK_HEADER_SIZE];
+        raw[64..72].copy_from_slice(&1_100u64.to_le_bytes());
+        raw[80..88].copy_from_slice(&4u64.to_le_bytes());
+        apply_update(&cache, pk, 1, &raw);
+
+        assert!(rearm_unconfirmed(&cache, 500, 30).is_empty());
+        assert_eq!(
+            snapshot(&cache, &pk),
+            (1_100, 4),
+            "the chain's own schedule stands"
         );
     }
 

--- a/crates/hydra-cranker/src/cache.rs
+++ b/crates/hydra-cranker/src/cache.rs
@@ -10,10 +10,12 @@ use std::{
 
 use solana_pubkey::Pubkey;
 
-use hydra_api::consts::{
-    base::{CRANKER_REWARD, STALENESS_THRESHOLD_SLOTS},
-    CRANK_HEADER_SIZE, SERIALIZED_META_SIZE,
+use hydra_api::{
+    consts::{self, CRANK_HEADER_SIZE},
+    SERIALIZED_META_SIZE,
 };
+
+use crate::mode;
 
 /// Minimal decoded projection of a Crank account — just the fields we need
 /// for eligibility checks. The full raw bytes live in `data` so the trigger
@@ -26,12 +28,32 @@ pub struct CrankEntry {
     /// recipient. Non-zero = `Close` must refund the remainder to this pubkey.
     pub authority: [u8; 32],
     pub next_exec_slot: u64,
+    /// Slots between executions. `Trigger` advances `next_exec_slot` by exactly
+    /// this much on-chain, so the cranker can replay that advance locally the
+    /// instant it submits — without waiting for the `programSubscribe` echo.
+    pub interval_slots: u64,
     pub remaining: u64,
     pub priority_tip: u64,
     pub rent_min: u64,
     /// `0` = cranker omits `SetComputeUnitLimit`.
     pub cu_limit: u32,
     pub data: Vec<u8>,
+}
+
+fn cranker_reward() -> u64 {
+    if mode::is_ephemeral() {
+        consts::ephemeral::CRANKER_REWARD
+    } else {
+        consts::base::CRANKER_REWARD
+    }
+}
+
+fn staleness_threshold_slots() -> u64 {
+    if mode::is_ephemeral() {
+        consts::ephemeral::STALENESS_THRESHOLD_SLOTS
+    } else {
+        consts::base::STALENESS_THRESHOLD_SLOTS
+    }
 }
 
 impl CrankEntry {
@@ -43,6 +65,7 @@ impl CrankEntry {
         }
         let authority: [u8; 32] = data[0..32].try_into().ok()?;
         let next_exec_slot = u64::from_le_bytes(data[64..72].try_into().ok()?);
+        let interval_slots = u64::from_le_bytes(data[72..80].try_into().ok()?);
         let remaining = u64::from_le_bytes(data[80..88].try_into().ok()?);
         let priority_tip = u64::from_le_bytes(data[88..96].try_into().ok()?);
         let rent_min = u64::from_le_bytes(data[104..112].try_into().ok()?);
@@ -52,6 +75,7 @@ impl CrankEntry {
             lamports,
             authority,
             next_exec_slot,
+            interval_slots,
             remaining,
             priority_tip,
             rent_min,
@@ -69,7 +93,7 @@ impl CrankEntry {
         if self.remaining == 0 {
             return false;
         }
-        let reward = CRANKER_REWARD.saturating_add(self.priority_tip);
+        let reward = cranker_reward().saturating_add(self.priority_tip);
         self.lamports >= self.rent_min.saturating_add(reward)
     }
 
@@ -117,18 +141,24 @@ impl CrankEntry {
         false
     }
 
+    /// Whether `cranker` is an acceptable `reporter` for the *ephemeral*
+    /// `Close`, which is permissionless only for unowned cranks.
+    pub fn close_reporter_allowed(&self, cranker: &Pubkey) -> bool {
+        self.authority == [0u8; 32] || self.authority == cranker.to_bytes()
+    }
+
     /// Mirrors on-chain `Close` pre-condition: exhausted OR underfunded OR
     /// stuck (`current_slot - next_exec_slot > STALENESS_THRESHOLD_SLOTS`).
     pub fn is_closable(&self, current_slot: u64) -> bool {
         if self.remaining == 0 {
             return true;
         }
-        let next_reward = CRANKER_REWARD.saturating_add(self.priority_tip);
+        let next_reward = cranker_reward().saturating_add(self.priority_tip);
         if self.lamports < self.rent_min.saturating_add(next_reward) {
             return true;
         }
         // `saturating_sub` keeps future-scheduled cranks trivially not stale.
-        current_slot.saturating_sub(self.next_exec_slot) > STALENESS_THRESHOLD_SLOTS
+        current_slot.saturating_sub(self.next_exec_slot) > staleness_threshold_slots()
     }
 }
 
@@ -147,6 +177,27 @@ pub enum CacheOutcome {
     Unchanged,
 }
 
+/// Replay `Trigger`'s on-chain effect on the cached entry the moment we submit,
+/// so re-fire timing follows the crank's own `interval_slots` instead of waiting
+/// for the `programSubscribe` echo (which lags by an unbounded number of slots).
+///
+/// Mirrors `processor/*/trigger.rs`'s `next_exec_slot += interval_slots`. Guarded
+/// by an equality check on `next_exec_slot`: if a notification already advanced the
+/// entry past the snapshot we fired on, that authoritative update wins and we don't
+/// double-advance. A late, *pre*-trigger notification can still overwrite this with
+/// a stale value — that self-heals, because the next fire then lands as
+/// `NotYetExecutable` and the caller's backoff absorbs it.
+pub fn advance_after_trigger(cache: &Cache, pubkey: Pubkey, fired_at_next_exec: u64) {
+    let mut guard = cache.lock().expect("cache poisoned");
+    if let Some(e) = guard.get_mut(&pubkey) {
+        // Only the entry we actually fired on; a newer echo supersedes us.
+        if e.next_exec_slot != fired_at_next_exec {
+            return;
+        }
+        e.next_exec_slot = e.next_exec_slot.saturating_add(e.interval_slots);
+    }
+}
+
 /// Apply a single account update to the cache. Removes entries that have
 /// been closed (zero lamports / empty data) or are no longer well-formed
 /// Crank accounts; otherwise inserts/updates the decoded entry.
@@ -155,7 +206,7 @@ pub enum CacheOutcome {
 /// the two stay byte-for-byte consistent.
 pub fn apply_update(cache: &Cache, pubkey: Pubkey, lamports: u64, data: &[u8]) -> CacheOutcome {
     let mut guard = cache.lock().expect("cache poisoned");
-    if lamports == 0 || data.is_empty() {
+    if data.is_empty() || (!crate::mode::is_ephemeral() && lamports == 0) {
         return if guard.remove(&pubkey).is_some() {
             CacheOutcome::Removed
         } else {
@@ -182,8 +233,9 @@ pub fn apply_update(cache: &Cache, pubkey: Pubkey, lamports: u64, data: &[u8]) -
 
 #[cfg(test)]
 mod tests {
+    use hydra_api::{consts::REMAINING_INFINITE, META_FLAG_WRITABLE};
+
     use super::*;
-    use hydra_api::consts::{CRANK_HEADER_SIZE, META_FLAG_WRITABLE};
 
     /// Build a raw crank buffer (120-byte header + one scheduled ix that lists
     /// `metas` in the on-chain tail wire layout).
@@ -198,6 +250,106 @@ mod tests {
         data.extend_from_slice(Pubkey::new_unique().as_ref()); // program_id
         data.extend_from_slice(&0u16.to_le_bytes()); // data_len = 0
         data
+    }
+
+    fn entry(next_exec_slot: u64, interval_slots: u64, remaining: u64) -> CrankEntry {
+        CrankEntry {
+            pubkey: Pubkey::new_unique(),
+            lamports: u64::MAX,
+            authority: [0u8; 32],
+            next_exec_slot,
+            interval_slots,
+            remaining,
+            priority_tip: 0,
+            rent_min: 0,
+            cu_limit: 0,
+            data: Vec::new(),
+        }
+    }
+
+    fn seed(cache: &Cache, e: CrankEntry) -> Pubkey {
+        let pk = e.pubkey;
+        cache.lock().unwrap().insert(pk, e);
+        pk
+    }
+
+    fn snapshot(cache: &Cache, pk: &Pubkey) -> (u64, u64) {
+        let g = cache.lock().unwrap();
+        let e = g.get(pk).unwrap();
+        (e.next_exec_slot, e.remaining)
+    }
+
+    #[test]
+    fn advance_replays_the_schedule_but_not_the_countdown() {
+        let cache = new_cache();
+        let pk = seed(&cache, entry(100, 5, 3));
+        advance_after_trigger(&cache, pk, 100);
+        assert_eq!(
+            snapshot(&cache, &pk),
+            (105, 3),
+            "next_exec += interval; remaining is left to the authoritative update"
+        );
+    }
+
+    #[test]
+    fn advance_never_exhausts_the_last_execution_locally() {
+        mode::init(false);
+        let cache = new_cache();
+        let pk = seed(&cache, entry(100, 5, 1));
+        advance_after_trigger(&cache, pk, 100);
+        assert_eq!(snapshot(&cache, &pk), (105, 1), "remaining stays 1");
+        let g = cache.lock().unwrap();
+        let e = g.get(&pk).unwrap();
+        assert!(e.is_eligible(105), "still triggerable at 105");
+        assert!(!e.is_closable(105), "must not be treated as exhausted");
+    }
+
+    #[test]
+    fn only_the_authority_may_report_a_close_of_an_owned_crank() {
+        let cranker = Pubkey::new_unique();
+        let mut e = entry(100, 5, 0);
+        assert!(
+            e.close_reporter_allowed(&cranker),
+            "unowned crank stays permissionlessly closable"
+        );
+
+        e.authority = Pubkey::new_unique().to_bytes();
+        assert!(
+            !e.close_reporter_allowed(&cranker),
+            "someone else's crank is not ours to close"
+        );
+
+        e.authority = cranker.to_bytes();
+        assert!(
+            e.close_reporter_allowed(&cranker),
+            "we are the authority, so the gate accepts us"
+        );
+    }
+
+    #[test]
+    fn advance_is_skipped_when_a_newer_echo_already_moved_the_entry() {
+        let cache = new_cache();
+        // A `programSubscribe` update landed first, advancing the entry to 105.
+        let pk = seed(&cache, entry(105, 5, 2));
+        // We fired on the older snapshot (100); the guard must not double-advance.
+        advance_after_trigger(&cache, pk, 100);
+        assert_eq!(
+            snapshot(&cache, &pk),
+            (105, 2),
+            "stale fire must not advance"
+        );
+    }
+
+    #[test]
+    fn advance_keeps_the_infinite_remaining_sentinel() {
+        let cache = new_cache();
+        let pk = seed(&cache, entry(100, 1, REMAINING_INFINITE));
+        advance_after_trigger(&cache, pk, 100);
+        assert_eq!(
+            snapshot(&cache, &pk),
+            (101, REMAINING_INFINITE),
+            "infinite cranks advance the schedule but never decrement remaining"
+        );
     }
 
     #[test]

--- a/crates/hydra-cranker/src/delegation.rs
+++ b/crates/hydra-cranker/src/delegation.rs
@@ -104,7 +104,9 @@ pub fn is_delegated(rpc: &RpcClient, account: &Pubkey) -> Result<bool> {
 /// then wait for the rollup to agree.
 ///
 /// Idempotent: a cranker restarting against a rollup it is already delegated to
-/// sends no transaction.
+/// sends no transaction. Returns whether *this* call delegated the account,
+/// which is what tells the shutdown path the delegation is ours to release —
+/// see [`undelegate`].
 ///
 /// **Paying for your own delegation.** The cranker is the sole signer and payer,
 /// which the delegation program does not support directly: `Delegate` requires

--- a/crates/hydra-cranker/src/delegation.rs
+++ b/crates/hydra-cranker/src/delegation.rs
@@ -1,0 +1,359 @@
+//! Delegation lifecycle for the cranker's own keypair (ephemeral mode only).
+//!
+//! On the rollup, a transaction's fee payer may only have its lamports change
+//! if the account is `delegated()` — see `access_permissions.rs` in
+//! magicblock-svm. The ephemeral `Trigger` credits the cranker its
+//! `CRANKER_REWARD`, which *is* a fee-payer balance change, so an undelegated
+//! cranker has every trigger rejected with `InvalidAccountForFee` and parks all
+//! of its cranks after `MAX_CONSECUTIVE_FAILURES`. Delegation is a hard
+//! precondition for ephemeral mode, not an optimization.
+//!
+//! The cranker keypair is an ordinary on-curve wallet, so this uses the
+//! *on-curve* delegation flow, and the cranker funds and signs it all itself —
+//! there is no second keypair. See [`ensure_delegated`] for the one non-obvious
+//! part of paying for your own delegation.
+
+use std::thread;
+use std::time::{Duration, Instant};
+
+use anyhow::{anyhow, bail, Result};
+use solana_client::rpc_client::RpcClient;
+use solana_commitment_config::CommitmentLevel;
+use solana_instruction::{AccountMeta, Instruction};
+use solana_keypair::Keypair;
+use solana_message::Message;
+use solana_pubkey::Pubkey;
+use solana_rpc_client_api::config::RpcSendTransactionConfig;
+use solana_rpc_client_api::request::RpcRequest;
+use solana_signature::Signature;
+use solana_signer::Signer;
+use solana_transaction::Transaction;
+use solana_transaction_status_client_types::UiTransactionEncoding;
+
+use ephemeral_rollups_sdk::consts::{MAGIC_CONTEXT_ID, MAGIC_PROGRAM_ID};
+use ephemeral_rollups_sdk::dlp_api::args::DelegateArgs;
+use ephemeral_rollups_sdk::dlp_api::instruction_builder::delegate;
+use ephemeral_rollups_sdk::pda::{
+    delegation_metadata_pda_from_delegated_account, delegation_record_pda_from_delegated_account,
+};
+
+use crate::metrics;
+
+/// Gap between `getDelegationStatus` polls while waiting for the rollup to
+/// catch up with a delegation.
+const POLL_INTERVAL: Duration = Duration::from_secs(2);
+
+/// Bytes of rent to pre-fund each delegation PDA with. Must be at least their
+/// real sizes — `DelegationRecord` is 96 bytes and an on-curve (empty-seed)
+/// `DelegationMetadata` is 53 — with margin, since over-funding is free
+/// (surplus is refunded when the delegation is torn down) but under-funding
+/// re-introduces the payer debit this whole scheme exists to avoid.
+const PREFUND_SPACE: usize = 256;
+
+/// `MagicBlockInstruction::ScheduleCommitAndUndelegate`, bincode-encoded: the
+/// enum is serialized as a `u32` LE variant index, and this is the third
+/// variant (`ModifyAccounts`, `ScheduleCommit`, then this one).
+const SCHEDULE_COMMIT_AND_UNDELEGATE: [u8; 4] = 2u32.to_le_bytes();
+
+fn to_local(pk: ephemeral_rollups_sdk::compat::Pubkey) -> Pubkey {
+    Pubkey::new_from_array(pk.to_bytes())
+}
+
+fn to_sdk(pk: &Pubkey) -> ephemeral_rollups_sdk::compat::Pubkey {
+    ephemeral_rollups_sdk::compat::Pubkey::new_from_array(pk.to_bytes())
+}
+
+fn delegation_program_id() -> Pubkey {
+    to_local(ephemeral_rollups_sdk::consts::DELEGATION_PROGRAM_ID)
+}
+
+/// Whether `account` is delegated, judged on the *base* layer: a delegated
+/// on-curve wallet is owned by the delegation program there.
+fn is_delegated_on_base(base: &RpcClient, account: &Pubkey) -> Result<bool> {
+    match base.get_account_with_commitment(account, base.commitment()) {
+        Ok(resp) => Ok(resp
+            .value
+            .is_some_and(|a| a.owner == delegation_program_id())),
+        Err(e) => Err(anyhow::Error::new(e).context("read cranker account on base")),
+    }
+}
+
+/// Ask the *rollup* whether `account` is delegated.
+///
+/// `getDelegationStatus` is a MagicBlock RPC extension returning
+/// `{"isDelegated": bool}`, read straight from the flag the fee-payer check
+/// consults, and it resolves the account against the base layer when the rollup
+/// has not cloned it yet.
+pub fn is_delegated(rpc: &RpcClient, account: &Pubkey) -> Result<bool> {
+    let status: serde_json::Value = rpc
+        .send(
+            RpcRequest::Custom {
+                method: "getDelegationStatus",
+            },
+            serde_json::json!([account.to_string()]),
+        )
+        .map_err(|e| anyhow::Error::new(e).context("getDelegationStatus"))?;
+
+    status
+        .get("isDelegated")
+        .and_then(serde_json::Value::as_bool)
+        .ok_or_else(|| anyhow!("getDelegationStatus returned no `isDelegated` field: {status}"))
+}
+
+/// Delegate the cranker keypair to the rollup's validator, unless it already is,
+/// then wait for the rollup to agree.
+///
+/// Idempotent: a cranker restarting against a rollup it is already delegated to
+/// sends no transaction.
+///
+/// **Paying for your own delegation.** The cranker is the sole signer and payer,
+/// which the delegation program does not support directly: `Delegate` requires
+/// the account to already be `assign`ed to the delegation program, and once it
+/// is, the *system* program can no longer debit it to fund the delegation PDAs —
+/// that CPI fails `ExternalAccountLamportSpend`. The way out is that DLP's
+/// `create_pda` only transfers from the payer when the target PDA is short of
+/// rent. So this pre-funds the record and metadata PDAs *before* the `assign`,
+/// while the cranker is still system-owned and can pay. `Delegate` then finds
+/// them funded, skips the transfer, and only allocates and assigns them.
+pub fn ensure_delegated(base: &RpcClient, er: &RpcClient, cranker: &Keypair) -> Result<bool> {
+    let acct = cranker.pubkey();
+    if is_delegated_on_base(base, &acct)? {
+        log::info!("cranker {acct} is already delegated");
+        return Ok(false);
+    }
+
+    // Pin the delegation to the rollup we actually crank for; a delegation to
+    // some other validator would not let this rollup adopt the account.
+    let validator = er
+        .get_identity()
+        .map_err(|e| anyhow::Error::new(e).context("read rollup validator identity"))?;
+    log::info!("delegating cranker {acct} to validator {validator}");
+
+    let record = to_local(delegation_record_pda_from_delegated_account(&to_sdk(&acct)));
+    let metadata = to_local(delegation_metadata_pda_from_delegated_account(&to_sdk(
+        &acct,
+    )));
+    let rent = base
+        .get_minimum_balance_for_rent_exemption(PREFUND_SPACE)
+        .map_err(|e| anyhow::Error::new(e).context("rent exemption for delegation PDAs"))?;
+
+    // Order is load-bearing: both transfers must execute while the cranker is
+    // still owned by the system program.
+    let ixs = vec![
+        solana_system_interface::instruction::transfer(&acct, &record, rent),
+        solana_system_interface::instruction::transfer(&acct, &metadata, rent),
+        solana_system_interface::instruction::assign(&acct, &delegation_program_id()),
+        // Empty `seeds` marks the account on-curve, skipping the PDA
+        // seed-derivation check.
+        to_local_instruction(delegate(
+            to_sdk(&acct),
+            to_sdk(&acct),
+            None,
+            DelegateArgs {
+                commit_frequency_ms: u32::MAX,
+                seeds: vec![],
+                validator: Some(to_sdk(&validator)),
+            },
+        )),
+    ];
+
+    send(base, &ixs, cranker, "delegate cranker")?;
+    log::info!("cranker {acct} delegated");
+    Ok(true)
+}
+
+/// Block until the rollup reports `account` as delegated, retrying until
+/// `timeout` elapses.
+///
+/// Separate from [`ensure_delegated`] because the base-layer transaction landing
+/// is not the same as the rollup having cloned the account and seen the flag;
+/// the trigger loop needs the latter.
+pub fn wait_until_delegated(rpc: &RpcClient, account: &Pubkey, timeout: Duration) -> Result<()> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        // A transient RPC failure should not end the wait, but if the wait ends
+        // *on* one, that error explains the timeout better than "not delegated".
+        let outcome = is_delegated(rpc, account);
+        match &outcome {
+            Ok(true) => {
+                log::info!("cranker {account} is delegated");
+                return Ok(());
+            }
+            Ok(false) => {}
+            Err(e) => log::debug!("delegation check for {account} failed: {e:#}"),
+        }
+        if Instant::now() >= deadline {
+            if let Err(e) = outcome {
+                return Err(e.context(format!(
+                    "could not determine whether cranker {account} is delegated within {timeout:?}"
+                )));
+            }
+            bail!(
+                "cranker {account} is not delegated to this rollup after {timeout:?}. \
+                 Ephemeral triggers credit the cranker its reward, and the rollup rejects a \
+                 fee payer whose lamports change unless it is delegated, so every trigger \
+                 would fail with `InvalidAccountForFee`."
+            );
+        }
+        thread::sleep(POLL_INTERVAL);
+    }
+}
+
+/// Commit the cranker's rollup balance back to L1 and release the delegation.
+///
+/// Submitted on the *rollup*: the delegation program's own client-side
+/// undelegate paths do not apply to an on-curve wallet — `RequestUndelegation`
+/// rejects on-curve accounts (DLP error 49) and `Undelegate` must be signed by
+/// the validator. The magic program accepts it because the account being
+/// released signs for itself (`signers.contains(committee_pubkey)`), which is
+/// what stands in for the usual owner-program CPI.
+///
+/// **The instruction's payer must not be the cranker**, which is why `payer` is
+/// a throwaway keypair rather than the cranker itself. `process_schedule_commit`
+/// marks every committee account undelegated (`set_delegated(false)`) and only
+/// *then* calls `charge_delegated_payer`, which requires the payer to still be
+/// delegated. With the cranker as both payer and sole committee it clears its
+/// own flag and fails its own check with `IllegalOwner`.
+///
+/// An undelegated payer sidesteps that entirely: `try_get_fee_vault` only
+/// demands a magic-fee-vault — and only charges a commit fee — when the payer is
+/// itself delegated, so a fresh keypair takes the no-vault path and is never
+/// debited. It therefore needs no lamports and no on-chain existence; it only
+/// has to sign. The vault must *not* be passed in that case either, or it would
+/// be read as the first committee account.
+pub fn undelegate(er: &RpcClient, cranker: &Keypair, payer: &Keypair) -> Result<()> {
+    let acct = cranker.pubkey();
+    log::info!("undelegating cranker {acct} (payer {})", payer.pubkey());
+    // `[payer(w,s), magic_context(w), accounts to commit+undelegate..]`. The
+    // cranker signs for itself, which is what clears the permission check in
+    // place of the usual owner-program CPI, and must be writable or
+    // undelegation is refused.
+    let ix = Instruction {
+        program_id: to_local(MAGIC_PROGRAM_ID),
+        accounts: vec![
+            // Read-only, unlike the SDK's builder: that marks the payer writable
+            // because it expects to charge it, but the rollup rejects a writable
+            // account that is not delegated (`InvalidWritableAccount`), and this
+            // one is deliberately neither.
+            AccountMeta::new_readonly(payer.pubkey(), true),
+            AccountMeta::new(to_local(MAGIC_CONTEXT_ID), false),
+            AccountMeta::new(acct, true),
+        ],
+        data: SCHEDULE_COMMIT_AND_UNDELEGATE.to_vec(),
+    };
+    // The *transaction* fee payer stays the cranker: it is funded and, being
+    // delegated, is allowed to have its balance move on the rollup. The
+    // throwaway only signs.
+    send_with(
+        er,
+        &[ix],
+        &cranker.pubkey(),
+        &[cranker, payer],
+        "undelegate cranker",
+    )?;
+    log::info!("cranker {acct} undelegation scheduled");
+    Ok(())
+}
+
+/// Sign, send, and confirm a one-off lifecycle transaction paid for by `signer`.
+fn send(rpc: &RpcClient, ixs: &[Instruction], signer: &Keypair, what: &str) -> Result<()> {
+    send_with(rpc, ixs, &signer.pubkey(), &[signer], what)
+}
+
+/// [`send`] with an explicit fee payer and signer set.
+///
+/// `skip_preflight` because on the rollup accounts are cloned from the base only
+/// on the real send path, so a simulation would fail on accounts that do not
+/// exist there yet. The signature is polled either way, so a revert still
+/// surfaces as an error.
+fn send_with(
+    rpc: &RpcClient,
+    ixs: &[Instruction],
+    fee_payer: &Pubkey,
+    signers: &[&Keypair],
+    what: &str,
+) -> Result<()> {
+    let blockhash = rpc.get_latest_blockhash().map_err(|e| {
+        metrics::metrics()
+            .rpc_errors_total
+            .with_label_values(&["get_latest_blockhash"])
+            .inc();
+        anyhow::Error::new(e).context("latest_blockhash")
+    })?;
+    let msg = Message::new_with_blockhash(ixs, Some(fee_payer), &blockhash);
+    let tx = Transaction::new(signers, msg, blockhash);
+    let sig = rpc
+        .send_transaction_with_config(
+            &tx,
+            RpcSendTransactionConfig {
+                skip_preflight: true,
+                max_retries: Some(5),
+                preflight_commitment: Some(CommitmentLevel::Processed),
+                ..Default::default()
+            },
+        )
+        .map_err(|e| {
+            metrics::metrics()
+                .rpc_errors_total
+                .with_label_values(&["send_transaction"])
+                .inc();
+            anyhow::Error::new(e).context(what.to_string())
+        })?;
+
+    let deadline = Instant::now() + Duration::from_secs(30);
+    loop {
+        match rpc.get_signature_status(&sig) {
+            Ok(Some(Ok(()))) => return Ok(()),
+            // A revert carries only the error code; the program's own `ic_msg!`
+            // explanation lives in the transaction logs, so replay it.
+            Ok(Some(Err(e))) => {
+                bail!("{what}: tx {sig} reverted: {e:?}{}", fetch_logs(rpc, &sig))
+            }
+            Ok(None) if Instant::now() < deadline => thread::sleep(Duration::from_millis(250)),
+            Ok(None) => bail!("{what}: tx {sig} not confirmed within 30s"),
+            Err(e) => return Err(anyhow::Error::new(e).context(format!("{what}: confirm"))),
+        }
+    }
+}
+
+/// Fetch a reverted transaction's own program logs, formatted for appending to
+/// an error. Best-effort: empty when the node cannot produce them.
+///
+/// Deliberately *not* a re-simulation. Replaying needs
+/// `replace_recent_blockhash` (the original blockhash has usually expired),
+/// which invalidates the signature and so forces `sig_verify: false` — and that
+/// empties the runtime's signer set. Programs that branch on who signed then
+/// fail somewhere else entirely, producing confident, wrong logs. The recorded
+/// transaction is the only faithful account of what happened.
+fn fetch_logs(rpc: &RpcClient, sig: &Signature) -> String {
+    let Ok(tx) = rpc.get_transaction(sig, UiTransactionEncoding::Base64) else {
+        return String::new();
+    };
+    let logs: Option<Vec<String>> = tx
+        .transaction
+        .meta
+        .map(|m| m.log_messages)
+        .and_then(Into::into);
+    match logs {
+        Some(logs) if !logs.is_empty() => format!("\n  logs:\n    {}", logs.join("\n    ")),
+        _ => String::new(),
+    }
+}
+
+/// Rebuild an SDK-built instruction with our own pubkey type, field by field:
+/// the SDK is built against an older `solana-pubkey` major than the cranker.
+fn to_local_instruction(ix: ephemeral_rollups_sdk::compat::Instruction) -> Instruction {
+    Instruction {
+        program_id: to_local(ix.program_id),
+        accounts: ix
+            .accounts
+            .into_iter()
+            .map(|m| AccountMeta {
+                pubkey: to_local(m.pubkey),
+                is_signer: m.is_signer,
+                is_writable: m.is_writable,
+            })
+            .collect(),
+        data: ix.data,
+    }
+}

--- a/crates/hydra-cranker/src/fire.rs
+++ b/crates/hydra-cranker/src/fire.rs
@@ -59,10 +59,15 @@ pub fn fire_trigger(
     entry: &CrankEntry,
     priority_fee_micro_lamports: u64,
     skip_preflight: bool,
-) -> Result<()> {
+) -> Result<Signature> {
     let scheduled = ix::scheduled_ixs_from_crank(&entry.data)
         .ok_or_else(|| anyhow!("malformed crank tail for {}", entry.pubkey))?;
-    let trigger = ix::base::trigger(entry.pubkey, cranker.pubkey());
+    // Same accounts in both programs; only the program ID differs.
+    let trigger = if crate::mode::is_ephemeral() {
+        ix::ephemeral::trigger(entry.pubkey, cranker.pubkey())
+    } else {
+        ix::base::trigger(entry.pubkey, cranker.pubkey())
+    };
     let blockhash = rpc.get_latest_blockhash().map_err(|e| {
         metrics::metrics()
             .rpc_errors_total
@@ -114,7 +119,7 @@ pub fn fire_trigger(
     if skip_preflight {
         confirm_or_fail(rpc, &signature)?;
     }
-    Ok(())
+    Ok(signature)
 }
 
 /// Poll `signature` until the cluster reports a status or the timeout
@@ -154,21 +159,32 @@ fn confirm_or_fail(rpc: &RpcClient, signature: &Signature) -> Result<()> {
     }
 }
 
-/// Submit a permissionless `Close`. The cranker keeps the `CRANKER_REWARD`
-/// bounty; the remaining rent goes to `entry.authority` if set, otherwise to
-/// the cranker (on-chain anti-grief check in close.rs).
+/// Submit a `Close`. The cranker keeps the `CRANKER_REWARD` bounty; the
+/// remaining rent goes to `entry.authority` if set, otherwise to the cranker
+/// (on-chain anti-grief check in close.rs).
+///
+/// Permissionless on the base program. The ephemeral one additionally gates an
+/// owned crank's `Close` to its authority, so in that mode callers must have
+/// checked [`CrankEntry::close_reporter_allowed`] first — the cranker signs as
+/// `reporter`, and a Close it isn't authorized for reverts every time.
 pub fn fire_close(
     rpc: &RpcClient,
     cranker: &Keypair,
     entry: &CrankEntry,
     priority_fee_micro_lamports: u64,
-) -> Result<()> {
+) -> Result<Signature> {
+    // Refund recipient: the authority if set (anti-grief binds it on-chain),
+    // otherwise the cranker itself.
     let recipient = if entry.authority == [0u8; 32] {
         cranker.pubkey()
     } else {
         Pubkey::new_from_array(entry.authority)
     };
-    let close = ix::base::close(cranker.pubkey(), entry.pubkey, recipient);
+    let close = if crate::mode::is_ephemeral() {
+        ix::ephemeral::close(cranker.pubkey(), entry.pubkey, recipient)
+    } else {
+        ix::base::close(cranker.pubkey(), entry.pubkey, recipient)
+    };
     let blockhash = rpc.get_latest_blockhash().map_err(|e| {
         metrics::metrics()
             .rpc_errors_total
@@ -198,6 +214,5 @@ pub fn fire_close(
             .with_label_values(&["send_transaction"])
             .inc();
         anyhow::Error::new(e).context("send_transaction")
-    })?;
-    Ok(())
+    })
 }

--- a/crates/hydra-cranker/src/main.rs
+++ b/crates/hydra-cranker/src/main.rs
@@ -396,10 +396,12 @@ fn main() -> Result<()> {
                     continue;
                 }
             }
-            // Only skip when `at_slot` still matches: a fresh `next_exec_slot`
-            // means the crank advanced and the prior failure record is stale.
+            // Only skip when `at_slot` still matches: a fresh *confirmed*
+            // `next_exec_slot` means the crank really advanced and the prior
+            // failure record is stale. The optimistic advance is excluded on
+            // purpose — it is our own guess, not evidence of progress.
             if let Some(state) = failures.get(&entry.pubkey) {
-                if state.at_slot == entry.next_exec_slot {
+                if state.at_slot == entry.confirmed_next_exec_slot() {
                     if state.count >= MAX_CONSECUTIVE_FAILURES {
                         parked_now += 1;
                         continue;
@@ -438,9 +440,11 @@ fn main() -> Result<()> {
                     // the crank's next fire follows its `interval_slots` instead
                     // of stalling until the `programSubscribe` echo catches up.
                     cache::advance_after_trigger(&cache, entry.pubkey, entry.next_exec_slot, slot);
-                    // Failure record clears only when the cache observes an
-                    // advanced `next_exec_slot`; submit-Ok alone isn't proof
-                    // the tx landed.
+                    // The failure record is deliberately left alone: it clears
+                    // only once the chain confirms an advanced `next_exec_slot`
+                    // (`CrankEntry::confirmed_next_exec_slot`), because the
+                    // advance just made above — like submit-Ok itself — is no
+                    // proof the tx landed.
                 }
                 Err(f) => {
                     log::debug!("slot {}: trigger {} dropped: {:#}", slot, entry.pubkey, f);
@@ -448,15 +452,18 @@ fn main() -> Result<()> {
                         .triggers_submitted_total
                         .with_label_values(&["err"])
                         .inc();
+                    // Anchored on the confirmed schedule, matching the staleness
+                    // test above.
+                    let at_slot = entry.confirmed_next_exec_slot();
                     let rec = failures.entry(entry.pubkey).or_insert(FailureState {
                         count: 0,
-                        at_slot: entry.next_exec_slot,
+                        at_slot,
                         next_retry_slot: 0,
                     });
-                    if rec.at_slot != entry.next_exec_slot {
+                    if rec.at_slot != at_slot {
                         *rec = FailureState {
                             count: 1,
-                            at_slot: entry.next_exec_slot,
+                            at_slot,
                             next_retry_slot: slot + retry_backoff_slots(1),
                         };
                     } else {
@@ -467,7 +474,7 @@ fn main() -> Result<()> {
                                 "parking crank {} after {} consecutive failures at slot {}: {:#}",
                                 entry.pubkey,
                                 rec.count,
-                                entry.next_exec_slot,
+                                at_slot,
                                 f
                             );
                         }

--- a/crates/hydra-cranker/src/main.rs
+++ b/crates/hydra-cranker/src/main.rs
@@ -34,6 +34,15 @@ const POST_SUBMIT_COOLDOWN_SLOTS: u64 = 1;
 /// purges the crank from the cache, so this map only tracks race losers.
 const CLOSE_RETRY_COOLDOWN_SLOTS: u64 = 10;
 
+/// How long an optimistically advanced `next_exec_slot` (see
+/// `cache::advance_after_trigger`) may go unconfirmed before it is undone. An
+/// accepted submit is not a landed transaction, and a dropped one produces no
+/// account change and therefore no `programSubscribe` echo to correct the
+/// cache — so without a bound the crank sits out a full interval on a fire that
+/// never happened. ~12 s of base-layer chain time, ~1.5 s on a rollup, both far
+/// above `processed`-commitment echo latency.
+const OPTIMISTIC_REARM_SLOTS: u64 = 30;
+
 struct FailureState {
     count: u32,
     at_slot: u64,
@@ -330,6 +339,17 @@ fn main() -> Result<()> {
         // Time the full sweep (scan + fire). `observe_duration` on drop.
         let _sweep = metrics::metrics().sweep_duration_seconds.start_timer();
 
+        // Before scanning: put back any crank whose submit was accepted but
+        // whose advance the chain never confirmed.
+        for pk in cache::rearm_unconfirmed(&cache, slot, OPTIMISTIC_REARM_SLOTS) {
+            log::warn!(
+                "slot {}: re-arming {} — no on-chain update confirmed its trigger within {} slots",
+                slot,
+                pk,
+                OPTIMISTIC_REARM_SLOTS
+            );
+        }
+
         // Close takes precedence: its staleness arm can overlap
         // `is_eligible`, and a stuck crank should be cleaned up rather than
         // re-fired.
@@ -417,7 +437,7 @@ fn main() -> Result<()> {
                     // Replay `Trigger`'s schedule advance in our cache now, so
                     // the crank's next fire follows its `interval_slots` instead
                     // of stalling until the `programSubscribe` echo catches up.
-                    cache::advance_after_trigger(&cache, entry.pubkey, entry.next_exec_slot);
+                    cache::advance_after_trigger(&cache, entry.pubkey, entry.next_exec_slot, slot);
                     // Failure record clears only when the cache observes an
                     // advanced `next_exec_slot`; submit-Ok alone isn't proof
                     // the tx landed.

--- a/crates/hydra-cranker/src/main.rs
+++ b/crates/hydra-cranker/src/main.rs
@@ -231,6 +231,12 @@ fn main() -> Result<()> {
     // only job is to be an *undelegated* instruction payer, which is what keeps
     // the magic program off its fee path. See `delegation::undelegate`.
     let undelegate_payer = Keypair::new();
+    // Whether *this process* took the delegation, which is what entitles it to
+    // release it on the way out. A pre-existing delegation belongs to whoever
+    // made it — an operator, a sponsor tool, or a second cranker on the same
+    // key — and tearing it down here would strand them on
+    // `InvalidAccountForFee`.
+    let mut delegated_by_us = false;
 
     if mode::is_ephemeral() {
         log::info!("undelegate payer = {}", undelegate_payer.pubkey());
@@ -239,7 +245,7 @@ fn main() -> Result<()> {
         })?;
         log::info!("base rpc = {}", url);
         let base = RpcClient::new_with_commitment(url, CommitmentConfig::confirmed());
-        delegation::ensure_delegated(&base, &rpc, &cranker)?;
+        delegated_by_us = delegation::ensure_delegated(&base, &rpc, &cranker)?;
         // Landing on the base layer is not the same as the rollup having seen
         // it; the trigger loop needs the rollup's view.
         delegation::wait_until_delegated(
@@ -492,9 +498,19 @@ fn main() -> Result<()> {
     // the rollup back to L1. Best-effort: triggering has already stopped, so a
     // failure costs nothing this run, and the next startup finds the account
     // still delegated and skips re-delegating.
+    //
+    // Only ours to release, though: a delegation that was already in place at
+    // startup is someone else's, and undelegating it would break whoever is
+    // relying on it.
     if mode::is_ephemeral() {
-        if let Err(e) = delegation::undelegate(&rpc, &cranker, &undelegate_payer) {
-            log::warn!("undelegate on shutdown failed, cranker stays delegated: {e:#}");
+        if delegated_by_us {
+            if let Err(e) = delegation::undelegate(&rpc, &cranker, &undelegate_payer) {
+                log::warn!("undelegate on shutdown failed, cranker stays delegated: {e:#}");
+            }
+        } else {
+            log::info!(
+                "leaving cranker {cranker_pubkey} delegated: the delegation predates this process"
+            );
         }
     }
 

--- a/crates/hydra-cranker/src/main.rs
+++ b/crates/hydra-cranker/src/main.rs
@@ -22,10 +22,13 @@ use solana_signer::Signer;
 /// Consecutive failures at the same `next_exec_slot` before a crank is parked.
 const MAX_CONSECUTIVE_FAILURES: u32 = 10;
 
-/// Slots to skip a crank after a successful submit. Absorbs the in-flight
-/// window where both our cache and the RPC's preflight bank are stale; without
-/// it, a second fire within the window lands as `NotYetExecutable` (0x1).
-const POST_SUBMIT_COOLDOWN_SLOTS: u64 = 3;
+/// Backstop floor between fires of the same crank, on top of the optimistic
+/// `next_exec_slot` advance done on every successful submit (see
+/// `cache::advance_after_trigger`). That advance is what normally gates re-fire
+/// to the crank's own `interval_slots`; this only matters when it can't move the
+/// schedule — `interval_slots == 0` ("every slot") cranks — where it caps the
+/// blind retry rate at one fire per slot until the `programSubscribe` echo lands.
+const POST_SUBMIT_COOLDOWN_SLOTS: u64 = 1;
 
 /// Slots between Close attempts on the same crank. Close is one-shot: success
 /// purges the crank from the cache, so this map only tracks race losers.
@@ -48,13 +51,14 @@ fn retry_backoff_slots(count: u32) -> u64 {
 }
 
 mod cache;
+mod delegation;
 mod fire;
 mod grpc;
 mod metrics;
+mod mode;
 mod watch;
 
 use cache::new_cache;
-use hydra_api::instruction as ix;
 
 #[derive(Parser, Debug)]
 #[command(
@@ -109,6 +113,12 @@ struct Cli {
         default_value_t = false
     )]
     trigger_skip_preflight: bool,
+    /// Target Hydra's ephemeral-rollup program instead of the base-layer one.
+    /// Switches the watched program ID, the `Close` account layout, and the
+    /// funding/eligibility model (ephemeral cranks hold zero lamports). Point
+    /// `--rpc-url` at a MagicBlock ephemeral validator.
+    #[arg(long, env = "HYDRA_CRANKER_EPHEMERAL", default_value_t = false)]
+    ephemeral: bool,
     /// Run *every* eligible crank, including ones whose scheduled instructions
     /// reference the cranker's own pubkey. Such cranks can't actually fire — as
     /// the fee payer the cranker is promoted to signer + writable, so the
@@ -117,6 +127,24 @@ struct Cli {
     /// are skipped by default; this flag opts back in.
     #[arg(long = "unsafe", env = "HYDRA_CRANKER_UNSAFE", default_value_t = false)]
     run_unsafe: bool,
+    /// Base-layer (L1) JSON-RPC endpoint. Required with `--ephemeral`: the
+    /// cranker keypair must be delegated for the rollup to let its balance
+    /// change as the trigger fee payer, and delegating is a base-layer
+    /// transaction. The cranker delegates itself here at startup if needed,
+    /// paying for it out of its own balance. Unused in base mode.
+    #[arg(long, env = "HYDRA_CRANKER_BASE_RPC_URL")]
+    base_rpc_url: Option<String>,
+    /// How long to wait, with `--ephemeral`, for the rollup to report the
+    /// cranker keypair as delegated before giving up and exiting. The cranker
+    /// polls `getDelegationStatus` for this long, covering the lag between the
+    /// base-layer delegation landing and the rollup cloning the account.
+    /// `0` checks exactly once.
+    #[arg(
+        long,
+        env = "HYDRA_CRANKER_DELEGATION_TIMEOUT_SECS",
+        default_value_t = 30
+    )]
+    delegation_timeout_secs: u64,
 }
 
 fn default_ws_url(rpc_url: &str) -> String {
@@ -155,9 +183,14 @@ fn main() -> Result<()> {
         .init();
 
     let args = Cli::parse();
+    mode::init(args.ephemeral);
     let cranker = load_keypair(&args.keypair)?;
     let cranker_pubkey = cranker.pubkey();
     log::info!("cranker pubkey = {}", cranker_pubkey);
+    log::info!(
+        "mode = {}",
+        if args.ephemeral { "ephemeral" } else { "base" }
+    );
     if args.run_unsafe {
         log::warn!("--unsafe: running cranks that reference the cranker's own pubkey");
     }
@@ -172,7 +205,7 @@ fn main() -> Result<()> {
     log::info!("rpc = {}", args.rpc_url);
     log::info!("ws  = {}", ws_url);
 
-    let program_id = ix::base::PROGRAM_ID;
+    let program_id = mode::program_id();
     let cache = new_cache();
     let shutdown = Arc::new(AtomicBool::new(false));
     // `at_slot` anchors each counter to an observed `next_exec_slot`: once
@@ -186,6 +219,36 @@ fn main() -> Result<()> {
     // Prometheus metrics endpoint (optional).
     if let Some(port) = args.prometheus_port {
         let _server = metrics::spawn_server(port);
+    }
+
+    // Ephemeral mode requires a delegated cranker: the rollup rejects a fee
+    // payer whose lamports change unless it is delegated, and every `Trigger`
+    // credits the cranker its reward. Fail fast here rather than let the
+    // trigger loop park every crank on `InvalidAccountForFee`. Base mode moves
+    // no fee-payer lamports this way and needs none of it.
+    // Throwaway signer for the shutdown undelegate. It is never a fee payer and
+    // never debited, so it needs no lamports and need not exist on-chain — its
+    // only job is to be an *undelegated* instruction payer, which is what keeps
+    // the magic program off its fee path. See `delegation::undelegate`.
+    let undelegate_payer = Keypair::new();
+
+    if mode::is_ephemeral() {
+        log::info!("undelegate payer = {}", undelegate_payer.pubkey());
+        let url = args.base_rpc_url.clone().ok_or_else(|| {
+            anyhow!("--base-rpc-url is required with --ephemeral (delegating the cranker keypair is a base-layer transaction)")
+        })?;
+        log::info!("base rpc = {}", url);
+        let base = RpcClient::new_with_commitment(url, CommitmentConfig::confirmed());
+        delegation::ensure_delegated(&base, &rpc, &cranker)?;
+        // Landing on the base layer is not the same as the rollup having seen
+        // it; the trigger loop needs the rollup's view.
+        delegation::wait_until_delegated(
+            &rpc,
+            &cranker_pubkey,
+            Duration::from_secs(args.delegation_timeout_secs),
+        )?;
+    } else if args.base_rpc_url.is_some() {
+        log::warn!("--base-rpc-url is ignored without --ephemeral");
     }
 
     // Initial bootstrap so the trigger loop has something to scan even if
@@ -202,12 +265,7 @@ fn main() -> Result<()> {
         cache.clone(),
         shutdown.clone(),
     );
-    let _slot_thread = watch::spawn_slot_watcher(
-        args.rpc_url.clone(),
-        ws_url,
-        shutdown.clone(),
-        slot_tx.clone(),
-    );
+    let _slot_thread = watch::spawn_slot_watcher(ws_url, shutdown.clone(), slot_tx.clone());
 
     // Optional Yellowstone gRPC source. Strictly additive — feeds the same
     // cache and slot channel as the WS watchers, so whichever delivers an
@@ -270,7 +328,9 @@ fn main() -> Result<()> {
             let mut elig = Vec::new();
             let mut clos = Vec::new();
             for entry in guard.values() {
-                if entry.is_closable(slot) {
+                let closable_by_us =
+                    !mode::is_ephemeral() || entry.close_reporter_allowed(&cranker_pubkey);
+                if entry.is_closable(slot) && closable_by_us {
                     clos.push(entry.clone());
                 } else if entry.is_eligible(slot) {
                     // A crank that references the cranker's own pubkey can never
@@ -331,19 +391,28 @@ fn main() -> Result<()> {
                 args.priority_fee_micro_lamports,
                 args.trigger_skip_preflight,
             ) {
-                Ok(()) => {
-                    log::info!("slot {}: triggered {}", slot, entry.pubkey);
+                Ok(signature) => {
+                    log::info!(
+                        "slot {}: triggered {} (tx {})",
+                        slot,
+                        entry.pubkey,
+                        signature
+                    );
                     metrics::metrics()
                         .triggers_submitted_total
                         .with_label_values(&["ok"])
                         .inc();
                     last_submit.insert(entry.pubkey, slot);
+                    // Replay `Trigger`'s schedule advance in our cache now, so
+                    // the crank's next fire follows its `interval_slots` instead
+                    // of stalling until the `programSubscribe` echo catches up.
+                    cache::advance_after_trigger(&cache, entry.pubkey, entry.next_exec_slot);
                     // Failure record clears only when the cache observes an
                     // advanced `next_exec_slot`; submit-Ok alone isn't proof
                     // the tx landed.
                 }
-                Err(e) => {
-                    log::debug!("slot {}: trigger {} dropped: {:#}", slot, entry.pubkey, e);
+                Err(f) => {
+                    log::debug!("slot {}: trigger {} dropped: {:#}", slot, entry.pubkey, f);
                     metrics::metrics()
                         .triggers_submitted_total
                         .with_label_values(&["err"])
@@ -368,7 +437,7 @@ fn main() -> Result<()> {
                                 entry.pubkey,
                                 rec.count,
                                 entry.next_exec_slot,
-                                e
+                                f
                             );
                         }
                     }
@@ -392,15 +461,16 @@ fn main() -> Result<()> {
                 }
             }
             match fire::fire_close(&rpc, &cranker, &entry, args.priority_fee_micro_lamports) {
-                Ok(()) => {
-                    log::info!("slot {}: closed {}", slot, entry.pubkey);
+                Ok(signature) => {
+                    log::info!("slot {}: closed {} (tx {})", slot, entry.pubkey, signature);
                     metrics::metrics()
                         .closes_submitted_total
                         .with_label_values(&["ok"])
                         .inc();
+                    last_close_attempt.insert(entry.pubkey, slot);
                 }
-                Err(e) => {
-                    log::debug!("slot {}: close {} dropped: {:#}", slot, entry.pubkey, e);
+                Err(f) => {
+                    log::debug!("slot {}: close {} dropped: {:#}", slot, entry.pubkey, f);
                     metrics::metrics()
                         .closes_submitted_total
                         .with_label_values(&["err"])
@@ -412,5 +482,16 @@ fn main() -> Result<()> {
     }
 
     shutdown.store(true, Ordering::Relaxed);
+
+    // Release the delegation on the way out, committing the rewards earned on
+    // the rollup back to L1. Best-effort: triggering has already stopped, so a
+    // failure costs nothing this run, and the next startup finds the account
+    // still delegated and skips re-delegating.
+    if mode::is_ephemeral() {
+        if let Err(e) = delegation::undelegate(&rpc, &cranker, &undelegate_payer) {
+            log::warn!("undelegate on shutdown failed, cranker stays delegated: {e:#}");
+        }
+    }
+
     std::process::exit(0);
 }

--- a/crates/hydra-cranker/src/main.rs
+++ b/crates/hydra-cranker/src/main.rs
@@ -17,6 +17,7 @@ use solana_client::rpc_client::RpcClient;
 use solana_commitment_config::CommitmentConfig;
 use solana_keypair::{read_keypair, read_keypair_file, Keypair};
 use solana_pubkey::Pubkey;
+use solana_rpc_client_api::client_error::{Error as ClientError, TransactionError};
 use solana_signer::Signer;
 
 /// Consecutive failures at the same `next_exec_slot` before a crank is parked.
@@ -42,6 +43,11 @@ const CLOSE_RETRY_COOLDOWN_SLOTS: u64 = 10;
 /// never happened. ~12 s of base-layer chain time, ~1.5 s on a rollup, both far
 /// above `processed`-commitment echo latency.
 const OPTIMISTIC_REARM_SLOTS: u64 = 30;
+
+/// Slots between delegation re-checks prompted by a rejected fee payer. The
+/// check is an RPC round-trip and the repair a base-layer transaction, so it
+/// must not run once per failing crank per slot.
+const DELEGATION_RECHECK_COOLDOWN_SLOTS: u64 = 50;
 
 struct FailureState {
     count: u32,
@@ -186,6 +192,44 @@ fn load_keypair(input: &str) -> Result<Keypair> {
     ))
 }
 
+/// Whether a trigger failure is the rollup refusing the cranker as fee payer —
+/// in ephemeral mode, the signature of a delegation that is no longer there.
+///
+/// Preflight and send failures carry the `TransactionError` structurally. The
+/// `--trigger-skip-preflight` path only gets the confirmed status formatted into
+/// a message, so that one is matched as text.
+fn is_invalid_fee_payer(err: &anyhow::Error) -> bool {
+    err.chain().any(|e| {
+        e.downcast_ref::<ClientError>()
+            .and_then(ClientError::get_transaction_error)
+            .is_some_and(|te| matches!(te, TransactionError::InvalidAccountForFee))
+    }) || format!("{err:#}").contains("InvalidAccountForFee")
+}
+
+/// Re-establish the cranker's delegation after the rollup rejected it as fee
+/// payer, unless the rollup still considers it delegated (in which case the
+/// failure was something else and there is nothing to repair).
+///
+/// Returns whether this call performed the delegation, so the caller can adopt
+/// it for the shutdown undelegate.
+fn recover_delegation(
+    base: &RpcClient,
+    er: &RpcClient,
+    cranker: &Keypair,
+    timeout: Duration,
+) -> Result<bool> {
+    if delegation::is_delegated(er, &cranker.pubkey())? {
+        return Ok(false);
+    }
+    log::warn!(
+        "cranker {} is no longer delegated; re-delegating",
+        cranker.pubkey()
+    );
+    let took = delegation::ensure_delegated(base, er, cranker)?;
+    delegation::wait_until_delegated(er, &cranker.pubkey(), timeout)?;
+    Ok(took)
+}
+
 fn main() -> Result<()> {
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info"))
         .format_timestamp_millis()
@@ -224,6 +268,7 @@ fn main() -> Result<()> {
     let mut last_submit: HashMap<Pubkey, u64> = HashMap::new();
     let mut last_close_attempt: HashMap<Pubkey, u64> = HashMap::new();
     let mut last_trigger_attempt_slot: Option<u64> = None;
+    let mut last_delegation_recheck: Option<u64> = None;
 
     // Prometheus metrics endpoint (optional).
     if let Some(port) = args.prometheus_port {
@@ -247,23 +292,31 @@ fn main() -> Result<()> {
     // `InvalidAccountForFee`.
     let mut delegated_by_us = false;
 
-    if mode::is_ephemeral() {
-        log::info!("undelegate payer = {}", undelegate_payer.pubkey());
+    let delegation_timeout = Duration::from_secs(args.delegation_timeout_secs);
+    // Kept for the whole run, not just startup: the trigger loop re-delegates
+    // through it when the rollup starts refusing the cranker as fee payer.
+    let base_rpc = if mode::is_ephemeral() {
         let url = args.base_rpc_url.clone().ok_or_else(|| {
             anyhow!("--base-rpc-url is required with --ephemeral (delegating the cranker keypair is a base-layer transaction)")
         })?;
         log::info!("base rpc = {}", url);
-        let base = RpcClient::new_with_commitment(url, CommitmentConfig::confirmed());
-        delegated_by_us = delegation::ensure_delegated(&base, &rpc, &cranker)?;
+        Some(RpcClient::new_with_commitment(
+            url,
+            CommitmentConfig::confirmed(),
+        ))
+    } else {
+        if args.base_rpc_url.is_some() {
+            log::warn!("--base-rpc-url is ignored without --ephemeral");
+        }
+        None
+    };
+
+    if let Some(base) = &base_rpc {
+        log::info!("undelegate payer = {}", undelegate_payer.pubkey());
+        delegated_by_us = delegation::ensure_delegated(base, &rpc, &cranker)?;
         // Landing on the base layer is not the same as the rollup having seen
         // it; the trigger loop needs the rollup's view.
-        delegation::wait_until_delegated(
-            &rpc,
-            &cranker_pubkey,
-            Duration::from_secs(args.delegation_timeout_secs),
-        )?;
-    } else if args.base_rpc_url.is_some() {
-        log::warn!("--base-rpc-url is ignored without --ephemeral");
+        delegation::wait_until_delegated(&rpc, &cranker_pubkey, delegation_timeout)?;
     }
 
     // Initial bootstrap so the trigger loop has something to scan even if
@@ -452,6 +505,27 @@ fn main() -> Result<()> {
                         .triggers_submitted_total
                         .with_label_values(&["err"])
                         .inc();
+                    // A rejected fee payer means the delegation taken at startup
+                    // is gone — an undelegation that was still in flight when we
+                    // started, or one issued from elsewhere. Nothing else in the
+                    // loop would ever notice: every crank simply fails until it
+                    // parks. Repair it, throttled, and drop the failure records
+                    // it caused.
+                    if let Some(base) = &base_rpc {
+                        let due = last_delegation_recheck
+                            .is_none_or(|at| slot >= at + DELEGATION_RECHECK_COOLDOWN_SLOTS);
+                        if due && is_invalid_fee_payer(&f) {
+                            last_delegation_recheck = Some(slot);
+                            match recover_delegation(base, &rpc, &cranker, delegation_timeout) {
+                                Ok(true) => {
+                                    delegated_by_us = true;
+                                    failures.clear();
+                                }
+                                Ok(false) => {}
+                                Err(e) => log::warn!("re-delegating the cranker failed: {e:#}"),
+                            }
+                        }
+                    }
                     // Anchored on the confirmed schedule, matching the staleness
                     // test above.
                     let at_slot = entry.confirmed_next_exec_slot();
@@ -542,4 +616,40 @@ fn main() -> Result<()> {
     }
 
     std::process::exit(0);
+}
+
+#[cfg(test)]
+mod tests {
+    use solana_rpc_client_api::client_error::ErrorKind;
+
+    use super::*;
+
+    #[test]
+    fn a_structured_fee_payer_rejection_is_recognised() {
+        let err = anyhow::Error::new(ClientError::from(ErrorKind::TransactionError(
+            TransactionError::InvalidAccountForFee,
+        )))
+        .context("send_transaction");
+        assert!(is_invalid_fee_payer(&err));
+    }
+
+    #[test]
+    fn the_skip_preflight_confirmation_message_is_recognised() {
+        // `fire::confirm_or_fail` only has the `TransactionError`'s Debug form.
+        let err = anyhow!(
+            "tx 4NqB reverted on-chain: {:?}",
+            TransactionError::InvalidAccountForFee
+        );
+        assert!(is_invalid_fee_payer(&err));
+    }
+
+    #[test]
+    fn other_failures_do_not_trigger_a_re_delegation() {
+        let err = anyhow::Error::new(ClientError::from(ErrorKind::TransactionError(
+            TransactionError::BlockhashNotFound,
+        )))
+        .context("send_transaction");
+        assert!(!is_invalid_fee_payer(&err));
+        assert!(!is_invalid_fee_payer(&anyhow!("malformed crank tail")));
+    }
 }

--- a/crates/hydra-cranker/src/main.rs
+++ b/crates/hydra-cranker/src/main.rs
@@ -265,7 +265,12 @@ fn main() -> Result<()> {
         cache.clone(),
         shutdown.clone(),
     );
-    let _slot_thread = watch::spawn_slot_watcher(ws_url, shutdown.clone(), slot_tx.clone());
+    let _slot_thread = watch::spawn_slot_watcher(
+        args.rpc_url.clone(),
+        ws_url,
+        shutdown.clone(),
+        slot_tx.clone(),
+    );
 
     // Optional Yellowstone gRPC source. Strictly additive — feeds the same
     // cache and slot channel as the WS watchers, so whichever delivers an

--- a/crates/hydra-cranker/src/mode.rs
+++ b/crates/hydra-cranker/src/mode.rs
@@ -1,0 +1,36 @@
+//! Runtime selection of the target Hydra program.
+//!
+//! The cranker is a single binary that can drive either the base-layer program
+//! or the ephemeral-rollup program; the choice is made once at startup from the
+//! `--ephemeral` flag (not a compile-time feature). The base and ephemeral
+//! cranks differ in their program ID, their `Close` account layout, and their
+//! funding model (ephemeral cranks hold zero lamports), so the hot paths consult
+//! this module rather than threading a flag through every call.
+
+use std::sync::OnceLock;
+
+use solana_pubkey::Pubkey;
+
+use hydra_api::instruction as ix;
+
+static EPHEMERAL: OnceLock<bool> = OnceLock::new();
+
+/// Record the selected mode. Call once, before any watcher or the trigger loop
+/// starts. Later calls are ignored.
+pub fn init(ephemeral: bool) {
+    let _ = EPHEMERAL.set(ephemeral);
+}
+
+/// Whether the cranker targets the ephemeral-rollup program.
+pub fn is_ephemeral() -> bool {
+    EPHEMERAL.get().copied().unwrap_or(false)
+}
+
+/// The program ID the cranker watches and submits to.
+pub fn program_id() -> Pubkey {
+    if is_ephemeral() {
+        ix::EPHEMERAL_PROGRAM_ID
+    } else {
+        ix::BASE_PROGRAM_ID
+    }
+}

--- a/crates/hydra-cranker/src/watch.rs
+++ b/crates/hydra-cranker/src/watch.rs
@@ -11,13 +11,7 @@
 //!
 //! Both threads auto-reconnect on disconnect with a fixed 5 s backoff.
 //! On reconnect the cache is re-bootstrapped via `getProgramAccounts` so
-//! we don't silently drift. The slot watcher additionally treats a degraded
-//! stream as a disconnect: slots flow constantly on a healthy cluster, so a
-//! quiet stream means the socket died without a close frame (half-open
-//! connection), and a stream whose slots trail an HTTP `getSlot` means the
-//! connection is throttled and replaying the past. Both are torn down for
-//! reconnect. The program watcher cannot do the same — an idle program is
-//! indistinguishable from a dead socket there.
+//! we don't silently drift.
 
 use std::{
     sync::{
@@ -25,7 +19,7 @@ use std::{
         mpsc, Arc,
     },
     thread,
-    time::{Duration, Instant},
+    time::Duration,
 };
 
 use crossbeam_channel::RecvTimeoutError;
@@ -76,7 +70,8 @@ pub fn spawn_program_watcher(
         while !shutdown.load(Ordering::Relaxed) {
             // Rebuild the RPC handle each attempt in case the previous one
             // is wedged.
-            let rpc = RpcClient::new(rpc_url.clone());
+            let rpc =
+                RpcClient::new_with_commitment(rpc_url.clone(), CommitmentConfig::processed());
             if let Err(e) = bootstrap(&rpc, &program_id, &cache) {
                 log::warn!("bootstrap failed: {:#}; retrying in 5s", e);
                 thread::sleep(Duration::from_secs(5));
@@ -182,7 +177,6 @@ pub(crate) fn record_outcome(cache: &Cache, pk: Pubkey, outcome: CacheOutcome) {
 /// each new slot the RPC node observes. Reconnect loop mirrors the program
 /// watcher.
 pub fn spawn_slot_watcher(
-    rpc_url: String,
     ws_url: String,
     shutdown: Arc<AtomicBool>,
     tick: mpsc::Sender<u64>,
@@ -193,11 +187,7 @@ pub fn spawn_slot_watcher(
                 .ws_reconnects_total
                 .with_label_values(&["slot"])
                 .inc();
-            // Fresh handle each attempt in case the previous one is wedged.
-            // Short timeout: the lag check runs inline in the watch loop, and
-            // a slow HTTP endpoint must never hold up slot tick forwarding.
-            let rpc = RpcClient::new_with_timeout(rpc_url.clone(), LAG_CHECK_RPC_TIMEOUT);
-            if let Err(e) = run_slot_watch(&ws_url, &rpc, &shutdown, &tick) {
+            if let Err(e) = run_slot_watch(&ws_url, &shutdown, &tick) {
                 log::warn!("slotSubscribe loop ended: {:#}; reconnecting in 5s", e);
                 thread::sleep(Duration::from_secs(5));
             }
@@ -205,83 +195,23 @@ pub fn spawn_slot_watcher(
     })
 }
 
-/// A healthy cluster emits a slot roughly every 400 ms. If the subscription
-/// stays silent this long, the connection died without a close frame and the
-/// channel will never report `Disconnected`; bail so the reconnect loop can
-/// rebuild it.
-const SLOT_SILENCE_LIMIT: Duration = Duration::from_secs(30);
-
-/// A degraded connection can also keep delivering *stale* slots at a trickle,
-/// which resets the silence timer while the stream falls ever further behind
-/// the chain — and cranks whose `start_slot` is past the stream's horizon
-/// never become eligible. Cross-check against an HTTP `getSlot` this often
-/// and bail once the stream lags by more than [`MAX_SLOT_LAG`] (~1 min of
-/// chain time).
-const LAG_CHECK_INTERVAL: Duration = Duration::from_secs(30);
-const MAX_SLOT_LAG: u64 = 150;
-const LAG_CHECK_RPC_TIMEOUT: Duration = Duration::from_secs(5);
-
-fn run_slot_watch(
-    ws_url: &str,
-    rpc: &RpcClient,
-    shutdown: &AtomicBool,
-    tick: &mpsc::Sender<u64>,
-) -> Result<()> {
+fn run_slot_watch(ws_url: &str, shutdown: &AtomicBool, tick: &mpsc::Sender<u64>) -> Result<()> {
     let (_sub, rx) = PubsubClient::slot_subscribe(ws_url).context("slotSubscribe connect")?;
     log::info!("slotSubscribe connected");
-    let mut last_slot_at = Instant::now();
-    let mut last_ws_slot: Option<u64> = None;
-    let mut last_lag_check = Instant::now();
     loop {
         if shutdown.load(Ordering::Relaxed) {
             break Ok(());
         }
         match rx.recv_timeout(Duration::from_secs(10)) {
             Ok(info) => {
-                last_slot_at = Instant::now();
-                last_ws_slot = Some(info.slot);
                 // If the receiver went away, we have nothing to do.
                 if tick.send(info.slot).is_err() {
                     break Ok(());
                 }
             }
-            Err(RecvTimeoutError::Timeout) => {
-                let silent = last_slot_at.elapsed();
-                if silent >= SLOT_SILENCE_LIMIT {
-                    anyhow::bail!(
-                        "no slot notification in {silent:?}; connection presumed half-open"
-                    );
-                }
-            }
+            Err(RecvTimeoutError::Timeout) => continue,
             Err(RecvTimeoutError::Disconnected) => {
                 anyhow::bail!("slotSubscribe channel disconnected")
-            }
-        }
-        if let Some(ws_slot) = last_ws_slot {
-            if last_lag_check.elapsed() >= LAG_CHECK_INTERVAL {
-                match rpc.get_slot_with_commitment(CommitmentConfig::processed()) {
-                    Ok(rpc_slot) if rpc_slot > ws_slot + MAX_SLOT_LAG => {
-                        anyhow::bail!(
-                            "slot stream lagging: ws={ws_slot} rpc={rpc_slot} \
-                             ({} slots behind)",
-                            rpc_slot - ws_slot
-                        );
-                    }
-                    Ok(_) => {}
-                    // A failed cross-check is not proof the stream is bad;
-                    // the silence limit still guards a fully dead connection.
-                    Err(e) => {
-                        metrics::metrics()
-                            .rpc_errors_total
-                            .with_label_values(&["get_slot"])
-                            .inc();
-                        log::debug!("slot lag check skipped: {e}");
-                    }
-                }
-                // Stamp after the attempt: a slow `getSlot` must not leave
-                // the timer already expired, or the loop would re-enter the
-                // blocking call after forwarding a single queued slot.
-                last_lag_check = Instant::now();
             }
         }
     }

--- a/crates/hydra-cranker/src/watch.rs
+++ b/crates/hydra-cranker/src/watch.rs
@@ -11,7 +11,13 @@
 //!
 //! Both threads auto-reconnect on disconnect with a fixed 5 s backoff.
 //! On reconnect the cache is re-bootstrapped via `getProgramAccounts` so
-//! we don't silently drift.
+//! we don't silently drift. The slot watcher additionally treats a degraded
+//! stream as a disconnect: slots flow constantly on a healthy cluster, so a
+//! quiet stream means the socket died without a close frame (half-open
+//! connection), and a stream whose slots trail an HTTP `getSlot` means the
+//! connection is throttled and replaying the past. Both are torn down for
+//! reconnect. The program watcher cannot do the same — an idle program is
+//! indistinguishable from a dead socket there.
 
 use std::{
     sync::{
@@ -19,7 +25,7 @@ use std::{
         mpsc, Arc,
     },
     thread,
-    time::Duration,
+    time::{Duration, Instant},
 };
 
 use crossbeam_channel::RecvTimeoutError;
@@ -177,6 +183,7 @@ pub(crate) fn record_outcome(cache: &Cache, pk: Pubkey, outcome: CacheOutcome) {
 /// each new slot the RPC node observes. Reconnect loop mirrors the program
 /// watcher.
 pub fn spawn_slot_watcher(
+    rpc_url: String,
     ws_url: String,
     shutdown: Arc<AtomicBool>,
     tick: mpsc::Sender<u64>,
@@ -187,7 +194,11 @@ pub fn spawn_slot_watcher(
                 .ws_reconnects_total
                 .with_label_values(&["slot"])
                 .inc();
-            if let Err(e) = run_slot_watch(&ws_url, &shutdown, &tick) {
+            // Fresh handle each attempt in case the previous one is wedged.
+            // Short timeout: the lag check runs inline in the watch loop, and
+            // a slow HTTP endpoint must never hold up slot tick forwarding.
+            let rpc = RpcClient::new_with_timeout(rpc_url.clone(), LAG_CHECK_RPC_TIMEOUT);
+            if let Err(e) = run_slot_watch(&ws_url, &rpc, &shutdown, &tick) {
                 log::warn!("slotSubscribe loop ended: {:#}; reconnecting in 5s", e);
                 thread::sleep(Duration::from_secs(5));
             }
@@ -195,23 +206,83 @@ pub fn spawn_slot_watcher(
     })
 }
 
-fn run_slot_watch(ws_url: &str, shutdown: &AtomicBool, tick: &mpsc::Sender<u64>) -> Result<()> {
+/// A healthy cluster emits a slot roughly every 400 ms (~50 ms on an ephemeral
+/// rollup). If the subscription stays silent this long, the connection died
+/// without a close frame and the channel will never report `Disconnected`; bail
+/// so the reconnect loop can rebuild it.
+const SLOT_SILENCE_LIMIT: Duration = Duration::from_secs(30);
+
+/// A degraded connection can also keep delivering *stale* slots at a trickle,
+/// which resets the silence timer while the stream falls ever further behind
+/// the chain — and cranks whose `start_slot` is past the stream's horizon
+/// never become eligible. Cross-check against an HTTP `getSlot` this often
+/// and bail once the stream lags by more than [`MAX_SLOT_LAG`] (~1 min of
+/// base-layer chain time, ~7 s of rollup time).
+const LAG_CHECK_INTERVAL: Duration = Duration::from_secs(30);
+const MAX_SLOT_LAG: u64 = 150;
+const LAG_CHECK_RPC_TIMEOUT: Duration = Duration::from_secs(5);
+
+fn run_slot_watch(
+    ws_url: &str,
+    rpc: &RpcClient,
+    shutdown: &AtomicBool,
+    tick: &mpsc::Sender<u64>,
+) -> Result<()> {
     let (_sub, rx) = PubsubClient::slot_subscribe(ws_url).context("slotSubscribe connect")?;
     log::info!("slotSubscribe connected");
+    let mut last_slot_at = Instant::now();
+    let mut last_ws_slot: Option<u64> = None;
+    let mut last_lag_check = Instant::now();
     loop {
         if shutdown.load(Ordering::Relaxed) {
             break Ok(());
         }
         match rx.recv_timeout(Duration::from_secs(10)) {
             Ok(info) => {
+                last_slot_at = Instant::now();
+                last_ws_slot = Some(info.slot);
                 // If the receiver went away, we have nothing to do.
                 if tick.send(info.slot).is_err() {
                     break Ok(());
                 }
             }
-            Err(RecvTimeoutError::Timeout) => continue,
+            Err(RecvTimeoutError::Timeout) => {
+                let silent = last_slot_at.elapsed();
+                if silent >= SLOT_SILENCE_LIMIT {
+                    anyhow::bail!(
+                        "no slot notification in {silent:?}; connection presumed half-open"
+                    );
+                }
+            }
             Err(RecvTimeoutError::Disconnected) => {
                 anyhow::bail!("slotSubscribe channel disconnected")
+            }
+        }
+        if let Some(ws_slot) = last_ws_slot {
+            if last_lag_check.elapsed() >= LAG_CHECK_INTERVAL {
+                match rpc.get_slot_with_commitment(CommitmentConfig::processed()) {
+                    Ok(rpc_slot) if rpc_slot > ws_slot + MAX_SLOT_LAG => {
+                        anyhow::bail!(
+                            "slot stream lagging: ws={ws_slot} rpc={rpc_slot} \
+                             ({} slots behind)",
+                            rpc_slot - ws_slot
+                        );
+                    }
+                    Ok(_) => {}
+                    // A failed cross-check is not proof the stream is bad;
+                    // the silence limit still guards a fully dead connection.
+                    Err(e) => {
+                        metrics::metrics()
+                            .rpc_errors_total
+                            .with_label_values(&["get_slot"])
+                            .inc();
+                        log::debug!("slot lag check skipped: {e}");
+                    }
+                }
+                // Stamp after the attempt: a slow `getSlot` must not leave
+                // the timer already expired, or the loop would re-enter the
+                // blocking call after forwarding a single queued slot.
+                last_lag_check = Instant::now();
             }
         }
     }


### PR DESCRIPTION
Closes #26

Adds --mode {base,ephemeral} selecting the program id and fee model, the
--unsafe triage filter in the crank cache, and self-delegation of the
cranker keypair so it can pay for triggers from inside the rollup.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>