### PR TITLE
ci: publish the cranker binary as npm packages

### DIFF
--- a/.github/packages/npm-package/package.json.tmpl
+++ b/.github/packages/npm-package/package.json.tmpl
@@ -1,0 +1,32 @@
+{
+  "name": "@magicblock-labs/${node_pkg}",
+  "description": "MagicBlock Hydra cranker (${node_pkg})",
+  "version": "${node_version}",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/magicblock-labs/hydra.git"
+  },
+  "bugs": {
+    "url": "https://github.com/magicblock-labs/hydra/issues"
+  },
+  "license": "MIT",
+  "private": false,
+  "author": "Magicblock Labs <dev@magicblock.gg>",
+  "homepage": "https://www.magicblock.xyz/",
+  "bin": {
+    "hydra-cranker": "bin/hydra-cranker"
+  },
+  "files": [
+    "bin"
+  ],
+  "os": [
+    "${node_os}"
+  ],
+  "cpu": [
+    "${node_arch}"
+  ],
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  }
+}

--- a/.github/workflows/publish-cranker.yml
+++ b/.github/workflows/publish-cranker.yml
@@ -18,11 +18,11 @@ on:
     types: [published]
   push:
     branches:
-      - 'release/v*'
+      - "release/v*"
   workflow_dispatch:
     inputs:
       dry_run:
-        description: 'Run in dry-run mode (no actual publishing)'
+        description: "Run in dry-run mode (no actual publishing)"
         required: true
         type: boolean
         default: true
@@ -53,10 +53,26 @@ jobs:
       fail-fast: false
       matrix:
         build:
-          - { NAME: linux-x64-glibc,   OS: ubuntu-latest,    TARGET: x86_64-unknown-linux-gnu }
-          - { NAME: linux-arm64-glibc, OS: ubuntu-24.04-arm, TARGET: aarch64-unknown-linux-gnu }
-          - { NAME: darwin-x64,        OS: macos-13,         TARGET: x86_64-apple-darwin }
-          - { NAME: darwin-arm64,      OS: macos-latest,     TARGET: aarch64-apple-darwin }
+          - {
+              NAME: linux-x64-glibc,
+              OS: ubuntu-24.04,
+              TARGET: x86_64-unknown-linux-gnu,
+            }
+          - {
+              NAME: linux-arm64-glibc,
+              OS: ubuntu-24.04-arm,
+              TARGET: aarch64-unknown-linux-gnu,
+            }
+          - {
+              NAME: darwin-x64,
+              OS: macos-15-intel,
+              TARGET: x86_64-apple-darwin,
+            }
+          - {
+              NAME: darwin-arm64,
+              OS: macos-latest,
+              TARGET: aarch64-apple-darwin,
+            }
 
     defaults:
       run:
@@ -64,6 +80,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
@@ -107,6 +125,10 @@ jobs:
       # duplicated, so the two can never drift. On a real release we additionally
       # require the git tag to name that same version.
       - name: Resolve version
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          RELEASE_TAG_IN: ${{ github.event.release.tag_name }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           version=$(cargo metadata --no-deps --format-version=1 \
@@ -116,10 +138,19 @@ jobs:
             exit 1
           fi
           release_tag="v$version"
-          if [ "${{ github.event_name }}" = "release" ]; then
-            release_tag="${{ github.event.release.tag_name }}"
+          if [ "$EVENT_NAME" = "release" ]; then
+            release_tag="$RELEASE_TAG_IN"
             if [ "${release_tag#v}" != "$version" ]; then
               echo "::error::tag '$release_tag' does not match $BIN_NAME version '$version'"
+              exit 1
+            fi
+          elif [ "$DRY_RUN" = "false" ]; then
+            # A real publish off a dispatch guesses the tag from the workspace
+            # version. Require that release to already exist: the upload step
+            # would otherwise *create* one from this ref, or overwrite the
+            # assets of an existing release with a different commit's binaries.
+            if ! gh release view "$release_tag" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+              echo "::error::no published release '$release_tag' — cut the release first, or re-run with dry_run"
               exit 1
             fi
           fi
@@ -137,8 +168,6 @@ jobs:
           echo "node_pkg=${node_pkg}" >> "$GITHUB_ENV"
 
           mkdir -p "${node_pkg}/bin"
-          # Rendered with node rather than `envsubst`, which isn't present on the
-          # macOS images. Parsing the result also validates the template.
           node -e '
             const fs = require("fs");
             const tmpl = fs.readFileSync(".github/packages/npm-package/package.json.tmpl", "utf8");
@@ -172,16 +201,6 @@ jobs:
           path: target/${{ matrix.build.TARGET }}/release/${{ env.release_name }}
           if-no-files-found: error
 
-      - name: Attach the binary to the GitHub release
-        if: env.DRY_RUN == 'false'
-        uses: svenstaro/upload-release-action@v2
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: target/${{ matrix.build.TARGET }}/release/${{ env.release_name }}
-          asset_name: ${{ env.release_name }}
-          tag: ${{ env.RELEASE_TAG }}
-          overwrite: true
-
       - name: Publish to npm
         working-directory: ${{ env.node_pkg }}
         env:
@@ -191,6 +210,21 @@ jobs:
           if [ "$DRY_RUN" = "true" ]; then
             echo "DRY_RUN=true — not publishing"
             npm publish --access public --dry-run
-          else
-            npm publish --access public
+            exit 0
           fi
+          pkg="@magicblock-labs/${node_pkg}@${node_version}"
+          if [ -n "$(npm view "$pkg" version 2>/dev/null || true)" ]; then
+            echo "$pkg is already published — nothing to do"
+            exit 0
+          fi
+          npm publish --access public
+
+      - name: Attach the binary to the GitHub release
+        if: env.DRY_RUN == 'false'
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: target/${{ matrix.build.TARGET }}/release/${{ env.release_name }}
+          asset_name: ${{ env.release_name }}
+          tag: ${{ env.RELEASE_TAG }}
+          overwrite: true

--- a/.github/workflows/publish-cranker.yml
+++ b/.github/workflows/publish-cranker.yml
@@ -1,0 +1,196 @@
+name: Publish cranker packages
+
+# Builds `hydra-cranker` for every supported platform and ships it two ways:
+#   1. as a raw binary attached to the GitHub release, and
+#   2. as a per-platform npm package `@magicblock-labs/hydra-cranker-<os>-<arch>`.
+#
+# npm's `os`/`cpu` fields make each package installable only on the platform it
+# was built for, so a consumer installs the one matching their machine (or lists
+# them as `optionalDependencies` and lets npm pick).
+#
+# Triggers:
+#   - `release: published`  -> real publish, version taken from the workspace
+#   - `push` to `release/v*`-> dry run (smoke-tests the pipeline)
+#   - `workflow_dispatch`   -> dry run by default, opt in to a real publish
+
+on:
+  release:
+    types: [published]
+  push:
+    branches:
+      - 'release/v*'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Run in dry-run mode (no actual publishing)'
+        required: true
+        type: boolean
+        default: true
+
+permissions:
+  contents: write
+
+concurrency:
+  group: publish-cranker-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  BIN_NAME: hydra-cranker
+  # Keep in sync with `rust-toolchain.toml` and the CI workflow.
+  RUST_VERSION: 1.91.1
+  # `[profile.release] lto = "thin"` is there for the on-chain SBF programs. On a
+  # host build it makes rustc embed LLVM bitcode into the rlibs, and Apple's
+  # linker ships an older libLTO than rustc's LLVM — it then fails to parse that
+  # bitcode and the macOS link dies. LTO buys the cranker nothing (it is I/O
+  # bound, not compute bound), so build it without.
+  CARGO_PROFILE_RELEASE_LTO: false
+
+jobs:
+  publish-cranker:
+    name: ${{ matrix.build.NAME }}
+    runs-on: ${{ matrix.build.OS }}
+    strategy:
+      fail-fast: false
+      matrix:
+        build:
+          - { NAME: linux-x64-glibc,   OS: ubuntu-latest,    TARGET: x86_64-unknown-linux-gnu }
+          - { NAME: linux-arm64-glibc, OS: ubuntu-24.04-arm, TARGET: aarch64-unknown-linux-gnu }
+          - { NAME: darwin-x64,        OS: macos-13,         TARGET: x86_64-apple-darwin }
+          - { NAME: darwin-arm64,      OS: macos-latest,     TARGET: aarch64-apple-darwin }
+
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+          targets: ${{ matrix.build.TARGET }}
+
+      # `registry-url` writes an .npmrc that reads NODE_AUTH_TOKEN, so the
+      # publish step needs no token juggling of its own.
+      - name: Install Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org/
+
+      # `yellowstone-grpc-proto` pulls in `protobuf-src`, which compiles protoc
+      # from source — that needs cmake and a C++ toolchain, both preinstalled on
+      # the GitHub-hosted images. Nothing else to install.
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.build.TARGET }}
+
+      # Dry run unless this is an actual published release, or a manual run that
+      # explicitly opted out.
+      - name: Resolve DRY_RUN
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "release" ]; then
+            echo "DRY_RUN=false" >> "$GITHUB_ENV"
+          elif [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "DRY_RUN=${{ github.event.inputs.dry_run }}" >> "$GITHUB_ENV"
+          else
+            echo "DRY_RUN=true" >> "$GITHUB_ENV"
+          fi
+
+      # No `--locked`: Cargo.lock is gitignored in this repo.
+      - name: Build
+        run: cargo build -p "$BIN_NAME" --release --target ${{ matrix.build.TARGET }}
+
+      # The npm version is *derived* from the workspace version rather than
+      # duplicated, so the two can never drift. On a real release we additionally
+      # require the git tag to name that same version.
+      - name: Resolve version
+        run: |
+          set -euo pipefail
+          version=$(cargo metadata --no-deps --format-version=1 \
+            | jq -r --arg bin "$BIN_NAME" '.packages[] | select(.name == $bin) | .version')
+          if [ -z "$version" ] || [ "$version" = "null" ]; then
+            echo "::error::could not read the $BIN_NAME version from cargo metadata"
+            exit 1
+          fi
+          release_tag="v$version"
+          if [ "${{ github.event_name }}" = "release" ]; then
+            release_tag="${{ github.event.release.tag_name }}"
+            if [ "${release_tag#v}" != "$version" ]; then
+              echo "::error::tag '$release_tag' does not match $BIN_NAME version '$version'"
+              exit 1
+            fi
+          fi
+          echo "node_version=$version" >> "$GITHUB_ENV"
+          echo "RELEASE_TAG=$release_tag" >> "$GITHUB_ENV"
+          echo "Publishing $BIN_NAME@$version"
+
+      - name: Assemble the npm package
+        run: |
+          set -euo pipefail
+          node_os=$(echo "${{ matrix.build.NAME }}" | cut -d '-' -f1)
+          node_arch=$(echo "${{ matrix.build.NAME }}" | cut -d '-' -f2)
+          node_pkg="${BIN_NAME}-${node_os}-${node_arch}"
+          export node_os node_arch node_pkg
+          echo "node_pkg=${node_pkg}" >> "$GITHUB_ENV"
+
+          mkdir -p "${node_pkg}/bin"
+          # Rendered with node rather than `envsubst`, which isn't present on the
+          # macOS images. Parsing the result also validates the template.
+          node -e '
+            const fs = require("fs");
+            const tmpl = fs.readFileSync(".github/packages/npm-package/package.json.tmpl", "utf8");
+            const out = tmpl.replace(/\$\{(\w+)\}/g, (_, key) => {
+              const value = process.env[key];
+              if (value === undefined) throw new Error(`template variable not set: ${key}`);
+              return value;
+            });
+            JSON.parse(out);
+            fs.writeFileSync(`${process.env.node_pkg}/package.json`, out);
+          '
+          cat "${node_pkg}/package.json"
+
+          cp "target/${{ matrix.build.TARGET }}/release/${BIN_NAME}" "${node_pkg}/bin/"
+          chmod +x "${node_pkg}/bin/${BIN_NAME}"
+
+          # Platform-suffixed copy for the GitHub release assets.
+          release_name="${BIN_NAME}-${{ matrix.build.NAME }}"
+          echo "release_name=${release_name}" >> "$GITHUB_ENV"
+          cp "target/${{ matrix.build.TARGET }}/release/${BIN_NAME}" \
+             "target/${{ matrix.build.TARGET }}/release/${release_name}"
+
+      # Every matrix entry builds natively, so the artifact must run here.
+      - name: Smoke-test the binary
+        run: ./${{ env.node_pkg }}/bin/${{ env.BIN_NAME }} --version
+
+      - name: Upload the binary as a workflow artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.release_name }}
+          path: target/${{ matrix.build.TARGET }}/release/${{ env.release_name }}
+          if-no-files-found: error
+
+      - name: Attach the binary to the GitHub release
+        if: env.DRY_RUN == 'false'
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: target/${{ matrix.build.TARGET }}/release/${{ env.release_name }}
+          asset_name: ${{ env.release_name }}
+          tag: ${{ env.RELEASE_TAG }}
+          overwrite: true
+
+      - name: Publish to npm
+        working-directory: ${{ env.node_pkg }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ "$DRY_RUN" = "true" ]; then
+            echo "DRY_RUN=true — not publishing"
+            npm publish --access public --dry-run
+          else
+            npm publish --access public
+          fi

--- a/Makefile
+++ b/Makefile
@@ -44,12 +44,19 @@ help: ## Show this help
 # ---------------------------------------------------------------------------
 # Build — on-chain SBF programs (artifacts land in target/deploy/*.so).
 # ---------------------------------------------------------------------------
-.PHONY: build build-examples build-anchor
+.PHONY: build build-cranker build-examples build-anchor
 
 build: ## build-sbf the noop + hydra programs
 	cargo build-sbf --manifest-path $(NOOP_MANIFEST)
 	cargo build-sbf --manifest-path $(BASE_MANIFEST)
 	cargo build-sbf --manifest-path $(EPHEMERAL_MANIFEST)
+
+# `[profile.release] lto = "thin"` is for the SBF programs. On a host build it
+# makes rustc embed LLVM bitcode into the rlibs, which Apple's linker (an older
+# libLTO than rustc's LLVM) can't parse — the macOS link then fails. LTO buys
+# the cranker nothing, so build it without. Mirrors the publish workflow.
+build-cranker: ## Build the release hydra-cranker binary (target/release/hydra-cranker)
+	CARGO_PROFILE_RELEASE_LTO=false cargo build -p hydra-cranker --release
 
 build-examples: ## build-sbf the native + pinocchio example programs
 	cargo build-sbf --manifest-path $(NATIVE_MANIFEST)

--- a/README.md
+++ b/README.md
@@ -240,6 +240,30 @@ deposit is always recoverable.
 
 ## Running the Cranker
 
+### Install
+
+Each release publishes a prebuilt `hydra-cranker` binary as a per-platform npm
+package, plus the same binaries as GitHub release assets. Pick the package that
+matches your machine:
+
+```sh
+npm install -g @magicblock-labs/hydra-cranker-linux-x64     # linux, x86_64
+npm install -g @magicblock-labs/hydra-cranker-linux-arm64    # linux, aarch64
+npm install -g @magicblock-labs/hydra-cranker-darwin-x64     # macOS, Intel
+npm install -g @magicblock-labs/hydra-cranker-darwin-arm64   # macOS, Apple silicon
+```
+
+npm's `os`/`cpu` metadata pins each package to its platform, so listing them all
+as `optionalDependencies` also works — npm installs only the one that applies.
+
+Or build from source:
+
+```sh
+cargo install --git https://github.com/magicblock-labs/hydra hydra-cranker
+```
+
+### Usage
+
 The cranker is event-driven and uses WebSocket subscriptions for account and
 slot updates. Optionally, a Yellowstone gRPC endpoint can be wired in
 alongside the WS subs (`--grpc-url`) for redundancy and lower latency.

--- a/README.md
+++ b/README.md
@@ -256,10 +256,14 @@ npm install -g @magicblock-labs/hydra-cranker-darwin-arm64   # macOS, Apple sili
 npm's `os`/`cpu` metadata pins each package to its platform, so listing them all
 as `optionalDependencies` also works — npm installs only the one that applies.
 
-Or build from source:
+Or build from source. `CARGO_PROFILE_RELEASE_LTO=false` turns off the thin LTO
+the workspace enables for the on-chain programs — on a host build it makes rustc
+embed LLVM bitcode that Apple's linker cannot parse, and the macOS link fails.
+Point `--tag` at the release you want, or drop it to build the tip of `main`:
 
 ```sh
-cargo install --git https://github.com/magicblock-labs/hydra hydra-cranker
+CARGO_PROFILE_RELEASE_LTO=false \
+  cargo install --git https://github.com/magicblock-labs/hydra --tag v0.2.0 hydra-cranker
 ```
 
 ### Usage


### PR DESCRIPTION
Stacked on #19.

Every release builds `hydra-cranker` for four platforms and ships each one as a per-platform npm package plus a raw binary on the GitHub release.

## What ships

| Platform | npm package | Release asset |
| --- | --- | --- |
| linux x86_64 | `@magicblock-labs/hydra-cranker-linux-x64` | `hydra-cranker-linux-x64-glibc` |
| linux aarch64 | `@magicblock-labs/hydra-cranker-linux-arm64` | `hydra-cranker-linux-arm64-glibc` |
| macOS Intel | `@magicblock-labs/hydra-cranker-darwin-x64` | `hydra-cranker-darwin-x64` |
| macOS Apple silicon | `@magicblock-labs/hydra-cranker-darwin-arm64` | `hydra-cranker-darwin-arm64` |

npm's `os`/`cpu` metadata pins each package to its platform, so consumers can also list all four as `optionalDependencies` and let npm resolve the right one.

## Triggers

- `release: published` — real publish. The tag must match the workspace version.
- push to `release/v*` — dry run, to smoke-test the pipeline before cutting a release.
- `workflow_dispatch` — dry run by default, with an opt-in to publish for real.

Needs an `NPM_TOKEN` repo secret with publish rights on the `@magicblock-labs` scope (the same one ephemeral-vrf uses).


## Verification

Ran the workflow's build and packaging steps locally on darwin-arm64:

- `make build-cranker` → `hydra-cranker 0.1.1`
- template render → valid `package.json`, version `0.1.1` from `cargo metadata`
- `npm publish --dry-run` → `@magicblock-labs/hydra-cranker-darwin-arm64@0.1.1`, 2 files, 4.4 MB packed
- `npm install <pkg>` → `node_modules/.bin/hydra-cranker` symlink resolves and runs

The workflow YAML parses. The matrix itself hasn't run on GitHub yet — a `workflow_dispatch` dry run after merge is the way to confirm the non-darwin-arm64 legs.