### PR TITLE
fix: bind crank PDA derivation to the payer

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Examples:
 use hydra_api::instruction::{self as ix, CreateArgs, ScheduledIx};
 
 let seed = [0x42u8; 32];
-let (crank, _bump) = ix::find_crank_pda(&seed);
+let (crank, _bump) = ix::find_crank_pda(&payer_pubkey, &seed);
 
 let create = ix::create(
     payer_pubkey,
@@ -175,7 +175,8 @@ ix[k]   = your scheduled ix(instructions_sysvar, ...)   // crank PDA not an acco
 
 In the scheduled program, reject unless:
 
-- `expected_crank_pda == Pubkey::find_program_address([b"crank", seed], hydra_id)`
+- `expected_crank_pda == Pubkey::find_program_address([b"crank", payer, seed], hydra_id)`
+  (payer-bound; the legacy `[b"crank", seed]` derivation is deprecated)
 - the previous ix program id is `hydra_id`
 - the previous ix discriminator is `Trigger`
 - the previous ix first account is the same crank PDA

--- a/crates/hydra-api/src/consts.rs
+++ b/crates/hydra-api/src/consts.rs
@@ -1,7 +1,8 @@
 //! Numeric constants, feature bits, and bounds that both the on-chain
 //! program and its clients reference.
 
-/// Seed prefix for the Crank PDA: `[b"crank", seed_bytes]`.
+/// Seed prefix for the Crank PDA: `[b"crank", payer, seed_bytes]`
+/// (legacy, deprecated: `[b"crank", seed_bytes]`).
 pub const CRANK_SEED_PREFIX: &[u8] = b"crank";
 
 /// Solana base transaction fee (lamports per signature).

--- a/crates/hydra-api/src/instruction.rs
+++ b/crates/hydra-api/src/instruction.rs
@@ -65,9 +65,18 @@ mod client {
         Pubkey::new_from_array(crate::ID.to_bytes())
     }
 
-    /// Derive `(crank_pda, bump)` using `solana_pubkey::Pubkey`.
-    pub fn find_crank_pda(seed: &[u8; 32]) -> (Pubkey, u8) {
-        let (addr, bump) = crate::state::find_crank_pda(seed);
+    /// Derive the payer-bound `(crank_pda, bump)` using `solana_pubkey::Pubkey`.
+    pub fn find_crank_pda(payer: &Pubkey, seed: &[u8; 32]) -> (Pubkey, u8) {
+        let (addr, bump) = crate::state::find_crank_pda(payer.as_array(), seed);
+        (Pubkey::new_from_array(addr.to_bytes()), bump)
+    }
+
+    /// Legacy unscoped derivation. Squattable by any payer.
+    // TODO: remove together with the legacy fallback in `Create`.
+    #[deprecated(note = "squattable; use the payer-bound `find_crank_pda`")]
+    pub fn find_crank_pda_unscoped(seed: &[u8; 32]) -> (Pubkey, u8) {
+        #[allow(deprecated)]
+        let (addr, bump) = crate::state::find_crank_pda_unscoped(seed);
         (Pubkey::new_from_array(addr.to_bytes()), bump)
     }
 

--- a/crates/hydra-api/src/state.rs
+++ b/crates/hydra-api/src/state.rs
@@ -32,7 +32,8 @@ pub struct Crank {
     /// All-zeros = no cancel authority (crank is fire-and-forget until it
     /// exhausts naturally or `Close` recovers rent permissionlessly).
     pub authority: [u8; 32],
-    /// The 32-byte seed bytes that derived this PDA (`[b"crank", seed]`).
+    /// The 32-byte seed bytes that derived this PDA
+    /// (`[b"crank", payer, seed]`, or legacy `[b"crank", seed]`).
     pub seed: [u8; 32],
     pub next_exec_slot: [u8; 8],
     pub interval_slots: [u8; 8],
@@ -182,9 +183,20 @@ pub unsafe fn load_crank_mut(bytes: &mut [u8]) -> Result<&mut Crank, ProgramErro
     Ok(&mut *(bytes.as_mut_ptr() as *mut Crank))
 }
 
-/// Derive the crank PDA for the given 32-byte seed.
+/// Derive the payer-bound crank PDA: `[b"crank", payer, seed]`.
 #[inline]
-pub fn find_crank_pda(seed: &[u8; 32]) -> (solana_address::Address, u8) {
+pub fn find_crank_pda(payer: &[u8; 32], seed: &[u8; 32]) -> (solana_address::Address, u8) {
+    solana_address::Address::find_program_address(
+        &[crate::consts::CRANK_SEED_PREFIX, payer.as_ref(), seed.as_ref()],
+        &crate::ID,
+    )
+}
+
+/// Legacy unscoped derivation: `[b"crank", seed]`. Squattable by any payer.
+// TODO: remove together with the legacy fallback in `Create`.
+#[deprecated(note = "squattable; use the payer-bound `find_crank_pda`")]
+#[inline]
+pub fn find_crank_pda_unscoped(seed: &[u8; 32]) -> (solana_address::Address, u8) {
     solana_address::Address::find_program_address(
         &[crate::consts::CRANK_SEED_PREFIX, seed.as_ref()],
         &crate::ID,

--- a/examples/anchor/programs/hydra-example-anchor/src/lib.rs
+++ b/examples/anchor/programs/hydra-example-anchor/src/lib.rs
@@ -51,7 +51,7 @@ pub mod hydra_example_anchor {
 pub struct Schedule<'info> {
     #[account(mut)]
     pub payer: Signer<'info>,
-    /// CHECK: Hydra validates this PDA matches `[b"crank", seed]` at Create.
+    /// CHECK: Hydra validates this PDA matches `[b"crank", payer, seed]` at Create.
     #[account(mut)]
     pub crank: UncheckedAccount<'info>,
     pub system_program: Program<'info, System>,

--- a/examples/anchor/programs/hydra-example-anchor/tests/mollusk.rs
+++ b/examples/anchor/programs/hydra-example-anchor/tests/mollusk.rs
@@ -63,9 +63,9 @@ fn schedule_creates_crank_via_cpi_into_hydra() {
 
     // Derive the crank PDA the example will create.
     let seed = [0x11u8; 32];
-    let (crank_addr, _bump) = hydra_api::state::find_crank_pda(&seed);
-    let crank = Pubkey::new_from_array(crank_addr.to_bytes());
     let payer = Pubkey::new_unique();
+    let (crank_addr, _bump) = hydra_api::state::find_crank_pda(&payer.to_bytes(), &seed);
+    let crank = Pubkey::new_from_array(crank_addr.to_bytes());
     let target_program_id = Pubkey::new_unique();
 
     let (system_program, system_program_acct) = keyed_account_for_system_program();

--- a/examples/native/src/lib.rs
+++ b/examples/native/src/lib.rs
@@ -6,7 +6,7 @@
 //!
 //! Account order:
 //!   0: payer            (writable, signer)
-//!   1: crank            (writable) — PDA at `[b"crank", seed]` in hydra-api
+//!   1: crank            (writable) — PDA at `[b"crank", payer, seed]` in hydra-api
 //!   2: system_program
 //!   3: hydra program    (implicit: pulled from hydra_api::ID inside the CPI)
 //!

--- a/examples/native/tests/mollusk.rs
+++ b/examples/native/tests/mollusk.rs
@@ -45,9 +45,9 @@ fn schedule_creates_crank_via_cpi_into_hydra() {
     // Derive the crank PDA. The seed must match what the example hard-codes
     // into its `CreateArgs` (it just passes through the user-supplied seed).
     let seed = [0x33u8; 32];
-    let (crank_addr, _bump) = hydra_api::state::find_crank_pda(&seed);
-    let crank = Pubkey::new_from_array(crank_addr.to_bytes());
     let payer = Pubkey::new_unique();
+    let (crank_addr, _bump) = hydra_api::state::find_crank_pda(&payer.to_bytes(), &seed);
+    let crank = Pubkey::new_from_array(crank_addr.to_bytes());
     let target_program_id = Pubkey::new_unique();
 
     // The example's ix data layout: [seed: 32][target_program_id: 32].

--- a/examples/pinocchio/tests/mollusk.rs
+++ b/examples/pinocchio/tests/mollusk.rs
@@ -48,9 +48,9 @@ fn schedule_creates_crank_via_cpi_into_hydra() {
 
     // Derive the crank PDA from the seed we'll pass in.
     let seed = [0x55u8; 32];
-    let (crank_addr, _bump) = hydra_api::state::find_crank_pda(&seed);
-    let crank = Pubkey::new_from_array(crank_addr.to_bytes());
     let payer = Pubkey::new_unique();
+    let (crank_addr, _bump) = hydra_api::state::find_crank_pda(&payer.to_bytes(), &seed);
+    let crank = Pubkey::new_from_array(crank_addr.to_bytes());
     let target_program_id = Pubkey::new_unique();
     let tick: &[u8] = b"tick";
 

--- a/programs/hydra/src/processor/create.rs
+++ b/programs/hydra/src/processor/create.rs
@@ -83,12 +83,26 @@ pub fn process(accounts: &mut [AccountView], data: &[u8]) -> ProgramResult {
         return Err(HydraError::InvalidSchedule.into());
     }
 
-    // Derive expected PDA and verify match.
-    let (expected_pda, bump) =
-        Address::find_program_address(&[CRANK_SEED_PREFIX, seed.as_ref()], &hydra_api::ID);
-    if crank_ai.address() != &expected_pda {
-        return Err(ProgramError::InvalidSeeds);
-    }
+    // Derive the payer-bound PDA (`[b"crank", payer, seed]`) — squat-proof:
+    // a different payer derives a different address.
+    let payer_key = payer.address();
+    let (expected_pda, bump) = Address::find_program_address(
+        &[CRANK_SEED_PREFIX, payer_key.as_ref(), seed.as_ref()],
+        &hydra_api::ID,
+    );
+    let payer_bound = crank_ai.address() == &expected_pda;
+    // DEPRECATED: legacy unscoped derivation (`[b"crank", seed]`) is squattable.
+    // TODO: remove this fallback once all integrators are on payer-bound PDAs.
+    let bump = if payer_bound {
+        bump
+    } else {
+        let (legacy_pda, legacy_bump) =
+            Address::find_program_address(&[CRANK_SEED_PREFIX, seed.as_ref()], &hydra_api::ID);
+        if crank_ai.address() != &legacy_pda {
+            return Err(ProgramError::InvalidSeeds);
+        }
+        legacy_bump
+    };
 
     let total_size = CRANK_HEADER_SIZE + upper_region;
 
@@ -98,12 +112,22 @@ pub fn process(accounts: &mut [AccountView], data: &[u8]) -> ProgramResult {
 
     // Sign the CreateAccount with the PDA's seeds so it owns itself on creation.
     let bump_arr = [bump];
-    let seeds_arr = [
+    let payer_seeds = [
+        Seed::from(CRANK_SEED_PREFIX),
+        Seed::from(payer_key.as_ref()),
+        Seed::from(seed.as_ref()),
+        Seed::from(&bump_arr),
+    ];
+    let legacy_seeds = [
         Seed::from(CRANK_SEED_PREFIX),
         Seed::from(seed.as_ref()),
         Seed::from(&bump_arr),
     ];
-    let signers = [Signer::from(&seeds_arr)];
+    let signers = [if payer_bound {
+        Signer::from(&payer_seeds[..])
+    } else {
+        Signer::from(&legacy_seeds[..])
+    }];
 
     #[cfg(feature = "create-account-allow-prefund")]
     {

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -56,8 +56,17 @@ pub fn load_noop(mollusk: &mut Mollusk) {
     mollusk.add_program(&NOOP_ID, NOOP_SO);
 }
 
+/// Legacy unscoped PDA — existing tests double as coverage of the
+/// deprecated `[b"crank", seed]` fallback in `Create`.
 pub fn find_crank(seed: &[u8; 32]) -> (Pubkey, u8) {
-    let (addr, bump) = hydra_api::state::find_crank_pda(seed);
+    #[allow(deprecated)]
+    let (addr, bump) = hydra_api::state::find_crank_pda_unscoped(seed);
+    (Pubkey::new_from_array(addr.to_bytes()), bump)
+}
+
+/// Payer-bound PDA (the current derivation).
+pub fn find_crank_for_payer(payer: &Pubkey, seed: &[u8; 32]) -> (Pubkey, u8) {
+    let (addr, bump) = hydra_api::state::find_crank_pda(&payer.to_bytes(), seed);
     (Pubkey::new_from_array(addr.to_bytes()), bump)
 }
 
@@ -616,6 +625,80 @@ mod tests {
         assert_eq!(header.executed(), 0);
         assert_eq!(header.region_len() as usize, region_len);
         assert!(header.rent_min() > 0, "rent_min should be cached");
+    }
+
+    #[test]
+    fn create_accepts_payer_bound_pda() {
+        let mollusk = mollusk_with_hydra();
+        let payer = Pubkey::new_unique();
+        let (crank_pda, _bump) = find_crank_for_payer(&payer, &SEED);
+
+        let ix = create_ix(
+            payer,
+            crank_pda,
+            SEED,
+            [0u8; 32],
+            0,
+            100,
+            10,
+            1_000,
+            0,
+            memo::ID,
+            &[],
+            b"tick",
+        );
+
+        let (system_program, system_program_acct) = keyed_account_for_system_program();
+        let accounts = vec![
+            (payer, Account::new(PAYER_LAMPORTS, 0, &system_program)),
+            (crank_pda, Account::default()),
+            (system_program, system_program_acct),
+        ];
+
+        let result = mollusk.process_transaction_instructions(&[ix], &accounts);
+        assert!(
+            result.raw_result.is_ok(),
+            "payer-bound create failed: {:?}",
+            result.raw_result
+        );
+    }
+
+    /// A squatter with a different payer derives a different PDA, so creating
+    /// at another payer's bound address must fail with `InvalidSeeds`.
+    #[test]
+    fn create_rejects_other_payers_bound_pda() {
+        let mollusk = mollusk_with_hydra();
+        let victim = Pubkey::new_unique();
+        let squatter = Pubkey::new_unique();
+        let (crank_pda, _bump) = find_crank_for_payer(&victim, &SEED);
+
+        let ix = create_ix(
+            squatter,
+            crank_pda,
+            SEED,
+            [0u8; 32],
+            0,
+            100,
+            10,
+            1_000,
+            0,
+            memo::ID,
+            &[],
+            b"tick",
+        );
+
+        let (system_program, system_program_acct) = keyed_account_for_system_program();
+        let accounts = vec![
+            (squatter, Account::new(PAYER_LAMPORTS, 0, &system_program)),
+            (crank_pda, Account::default()),
+            (system_program, system_program_acct),
+        ];
+
+        let result = mollusk.process_transaction_instructions(&[ix], &accounts);
+        assert!(
+            result.raw_result.is_err(),
+            "create must reject another payer's bound PDA"
+        );
     }
 
     /// A crank PDA that already holds lamports can't be created with a single


### PR DESCRIPTION
A crank address derived only from a public seed can be created first by any payer

`Create` now prefers the payer-bound derivation `[b"crank", payer, seed]` — a different payer derives a different address, so creating at someone else's crank address fails with `InvalidSeeds`. The legacy unscoped `[b"crank", seed]` derivation is still accepted as a deprecated fallback so existing clients keep working (marked with a removal TODO).

- `hydra-api`: `find_crank_pda` now takes the payer; the old derivation survives as `#[deprecated] find_crank_pda_unscoped`
- `Trigger`/`Cancel`/`Close` never re-derive, so the account layout and all deployed cranks are untouched
- Examples and README updated to the payer-bound derivation
- Tests: existing suite runs on the legacy helper (covers the fallback); new tests assert payer-bound create succeeds and a different payer is rejected
