### PR TITLE
ci: use shared Magic Lab project automation

### DIFF
--- a/.github/workflows/auto_add_to_board.yml
+++ b/.github/workflows/auto_add_to_board.yml
@@ -1,0 +1,19 @@
+name: Magic Lab Project Automation
+
+on:
+  issues:
+    types: [opened, reopened, transferred, labeled, unlabeled]
+  pull_request:
+    types: [opened, reopened, labeled, closed]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  magic-lab:
+    name: Update Magic Lab
+    uses: magicblock-labs/.github/.github/workflows/magic_lab_automation.yml@21cae0c2ecb071828423f673076e887f8a5fe63d
+    secrets:
+      ADD_TO_PROJECT_PAT: ${{ secrets.ADD_TO_PROJECT_PAT }}


### PR DESCRIPTION
Adds the repository-level event triggers for the shared Magic Lab project automation.

The caller pins reusable workflow commit 21cae0c2ecb071828423f673076e887f8a5fe63d from magicblock-labs/.github#3.

Automation includes:
- add issues and pull requests to Magic Lab
- assign unassigned items to their author
- map P0-P3 labels to the Priority issue field
- close linked issues after a pull request is merged

Prerequisite: expose the ADD_TO_PROJECT_PAT organization secret to this repository.

Validated with actionlint 1.7.12.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automation to manage issue and pull-request lifecycle events in the project board.
  * Enabled the required repository permissions for this workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->